### PR TITLE
fix: restore tool cursor after camera pan

### DIFF
--- a/src/systems/render/camera/hooks.ts
+++ b/src/systems/render/camera/hooks.ts
@@ -35,7 +35,9 @@ export function useCameraGestures(gl: THREE.WebGLRenderer, cameraMode: "persp" |
         setIsSpaceDown(false);
         if (isPanDragging) setIsPanDragging(false);
         setCameraGestureActive(isRotateDragging);
-        canvas.style.cursor = isRotateDragging ? "auto" : "auto";
+        canvas.style.cursor = isRotateDragging
+          ? "auto"
+          : getCursorForTool(activeTool) ?? "auto";
       }
     };
     const onPointerDown = (e: PointerEvent) => {
@@ -85,6 +87,7 @@ export function useCameraGestures(gl: THREE.WebGLRenderer, cameraMode: "persp" |
     cameraMode,
     setCameraGestureActive,
     isRotateDragging,
+    activeTool,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure cursor returns to active tool after finishing space-pan gesture

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689967599e6c8325b26dd83784591896