### PR TITLE
Handle zero modifier in useCurrencyBRL

### DIFF
--- a/src/ui/hooks/useCurrencyBRL.ts
+++ b/src/ui/hooks/useCurrencyBRL.ts
@@ -5,7 +5,7 @@ export function useCurrencyBRL(): (value: number, modifier?: number) => string {
     maximumFractionDigits: 2,
   });
   return (value: number, modifier?: number) => {
-    if (modifier) {
+    if (modifier !== undefined) {
       return fmt.format(value * modifier);
     }
     return fmt.format(value);


### PR DESCRIPTION
## Summary
- handle 0 modifier in `useCurrencyBRL`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*
- `node -e "const useCurrencyBRL=()=>{const fmt=new Intl.NumberFormat('pt-BR',{style:'currency',currency:'BRL',maximumFractionDigits:2});return (value,modifier)=>{if(modifier!==undefined){return fmt.format(value*modifier);}return fmt.format(value);};};const fmtFn=useCurrencyBRL();console.log(fmtFn(10));console.log(fmtFn(10,0));console.log(fmtFn(10,2.5));"`

------
https://chatgpt.com/codex/tasks/task_e_689969003b4c83259bf7a86a38fef621