### PR TITLE
docs: update validation pipeline

### DIFF
--- a/docs/validation_pipeline.md
+++ b/docs/validation_pipeline.md
@@ -1,9 +1,24 @@
 # Pipeline de Validação
-1. Snap (grid, parede ou slot)
-2. Colisão (footprint vs objetos)
-3. Clearance (tiles livres)
-4. Requisitos:
-   - needs_wall
-   - door/window em segmento de parede
-   - requires_slots
-5. Retorno { ok: boolean, reason?: string }
+
+O pipeline de validação é composto por uma sequência de validadores que
+garantem se um item pode ser colocado no lote. O `createDefaultPlacementPipeline`
+atualmente encadeia os seguintes validadores:
+
+1. **BoundsValidator** – impede que o *footprint* do item fique fora dos
+   limites do lote.
+2. **ObjectsCollisionValidator** – verifica colisões com outros objetos já
+   posicionados.
+
+### Etapas planejadas
+
+As etapas abaixo ainda não estão implementadas e serão adicionadas no futuro:
+
+- Snap (grid, parede ou slot)
+- Clearance (tiles livres)
+- Requisitos:
+  - needs_wall
+  - door/window em segmento de parede
+  - requires_slots
+
+O retorno do pipeline segue o formato `{ ok: boolean, reason?: string }`.
+


### PR DESCRIPTION
## Summary
- document that the validation pipeline currently runs BoundsValidator and ObjectsCollisionValidator
- note future steps like snap, clearance and requirements

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689969dcd16c8325b27652bb5f6aa106