### PR TITLE
feat: add instance capacity hook

### DIFF
--- a/src/systems/render/FloorLayer.tsx
+++ b/src/systems/render/FloorLayer.tsx
@@ -1,13 +1,10 @@
-import { useEffect, useState } from "react";
 import { useStore } from "../../store/useStore";
 import { Instances, Instance } from "@react-three/drei";
+import { useInstanceCapacity } from "./useInstanceCapacity";
 
 export function FloorLayer() {
   const floor = useStore((s) => s.floor);
-  const [capacity, setCapacity] = useState(() => Math.max(floor.length, 1));
-  useEffect(() => {
-    if (floor.length > capacity) setCapacity(Math.max(floor.length, capacity * 2));
-  }, [floor.length, capacity]);
+  const [capacity] = useInstanceCapacity(floor.length);
   return (
     <Instances key={capacity} limit={capacity}>
       <planeGeometry args={[1, 1]} />

--- a/src/systems/render/ObjectsLayer.tsx
+++ b/src/systems/render/ObjectsLayer.tsx
@@ -1,21 +1,18 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useEffect } from "react";
 import { useStore } from "../../store/useStore";
 import { catalog } from "../../core/catalog";
 import { CatalogItem3D } from "../../core/types";
 import type { ThreeEvent } from "@react-three/fiber";
-import { useEffect, useState } from "react";
 import { Instances, Instance } from "@react-three/drei";
+import { useInstanceCapacity } from "./useInstanceCapacity";
 
 export function ObjectsLayer() {
   const objects = useStore((s) => s.objects);
   const lot = useStore((s) => s.lot);
-  const [capacity, setCapacity] = useState(() =>
-    Math.max(lot.width * lot.depth, objects.length, 1),
-  );
+  const [capacity, updateCapacity] = useInstanceCapacity(objects.length);
   useEffect(() => {
-    const target = Math.max(lot.width * lot.depth, objects.length, capacity);
-    if (target > capacity) setCapacity(Math.max(target, capacity * 2));
-  }, [objects.length, lot.width, lot.depth, capacity]);
+    updateCapacity(lot.width * lot.depth);
+  }, [lot.width, lot.depth, updateCapacity]);
   const setHover = useStore((s) => s.setHover);
   const setSelected = useStore((s) => s.setSelected);
   const hoverId = useStore((s) => s.hoverId);

--- a/src/systems/render/WallsLayer.tsx
+++ b/src/systems/render/WallsLayer.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useState } from "react";
 import { useStore } from "../../store/useStore";
 import { Instances, Instance } from "@react-three/drei";
+import { useInstanceCapacity } from "./useInstanceCapacity";
 
 export function WallsLayer() {
   const walls = useStore((s) => s.walls);
   const height = useStore((s) => s.lot.height);
   const thickness = 0.1;
-  const [capacity, setCapacity] = useState(() => Math.max(walls.length, 1));
-  useEffect(() => {
-    if (walls.length > capacity) setCapacity(Math.max(walls.length, capacity * 2));
-  }, [walls.length, capacity]);
+  const [capacity] = useInstanceCapacity(walls.length);
   return (
     <Instances key={capacity} limit={capacity}>
       <boxGeometry args={[1, height, thickness]} />

--- a/src/systems/render/useInstanceCapacity.ts
+++ b/src/systems/render/useInstanceCapacity.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect, useCallback } from "react";
+
+export function useInstanceCapacity(length: number) {
+  const [capacity, setCapacity] = useState(() => Math.max(length, 1));
+
+  useEffect(() => {
+    if (length > capacity) {
+      setCapacity(Math.max(length, capacity * 2));
+    }
+  }, [length, capacity]);
+
+  const updateCapacity = useCallback(
+    (min = 0) => {
+      const target = Math.max(length, min);
+      if (target > capacity) {
+        setCapacity(Math.max(target, capacity * 2));
+      }
+    },
+    [length, capacity],
+  );
+
+  return [capacity, updateCapacity] as const;
+}


### PR DESCRIPTION
## Summary
- extract useInstanceCapacity hook for handling instanced mesh capacities
- use new hook across objects, walls and floor layers

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68996e460cc88325ab57e3b1e63dd91a