### PR TITLE
refactor: split camera and input slices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist
 *.local
 *.env
 coverage
+*.tsbuildinfo
 

--- a/src/store/cameraSlice.ts
+++ b/src/store/cameraSlice.ts
@@ -1,0 +1,26 @@
+import { StateCreator } from "zustand";
+
+export interface CameraSlice {
+  camera: {
+    mode: "persp" | "ortho";
+    controlsEnabled: boolean;
+    gestureActive: boolean;
+    setMode: (m: "persp" | "ortho") => void;
+    setControlsEnabled: (enabled: boolean) => void;
+    setGestureActive: (active: boolean) => void;
+  };
+}
+
+export const createCameraSlice: StateCreator<CameraSlice, [], [], CameraSlice> = (set) => ({
+  camera: {
+    mode: "persp",
+    controlsEnabled: true,
+    gestureActive: false,
+    setMode: (m) => set((s) => ({ camera: { ...s.camera, mode: m } })),
+    setControlsEnabled: (enabled) =>
+      set((s) => ({ camera: { ...s.camera, controlsEnabled: enabled } })),
+    setGestureActive: (active) =>
+      set((s) => ({ camera: { ...s.camera, gestureActive: active } })),
+  },
+});
+

--- a/src/store/inputSlice.ts
+++ b/src/store/inputSlice.ts
@@ -1,0 +1,32 @@
+import { StateCreator } from "zustand";
+
+export interface InputSlice {
+  input: {
+    pointerNdc: { x: number; y: number };
+    groundPoint: { x: number; y: number; z: number } | null;
+    keysDown: Record<string, boolean>;
+    setPointerNdc: (x: number, y: number) => void;
+    setGroundPoint: (gp: { x: number; y: number; z: number } | null) => void;
+    setKeyDown: (code: string, down: boolean) => void;
+  };
+}
+
+export const createInputSlice: StateCreator<InputSlice, [], [], InputSlice> = (set) => ({
+  input: {
+    pointerNdc: { x: 0, y: 0 },
+    groundPoint: null,
+    keysDown: {},
+    setPointerNdc: (x, y) =>
+      set((s) => ({ input: { ...s.input, pointerNdc: { x, y } } })),
+    setGroundPoint: (gp) =>
+      set((s) => ({ input: { ...s.input, groundPoint: gp } })),
+    setKeyDown: (code, down) =>
+      set((s) => ({
+        input: {
+          ...s.input,
+          keysDown: { ...s.input.keysDown, [code]: down },
+        },
+      })),
+  },
+});
+

--- a/src/systems/controllers/InputController.tsx
+++ b/src/systems/controllers/InputController.tsx
@@ -8,9 +8,9 @@ import { eventBus } from "../../core/events";
 // Mediator/Observer: centraliza eventos de ponteiro/teclado e publica no store
 export function InputController() {
   const { camera, gl } = useThree();
-  const setPointerNdc = useStore((s) => s.setPointerNdc);
-  const setGroundPoint = useStore((s) => s.setGroundPoint);
-  const setKeyDown = useStore((s) => s.setKeyDown);
+  const setPointerNdc = useStore((s) => s.input.setPointerNdc);
+  const setGroundPoint = useStore((s) => s.input.setGroundPoint);
+  const setKeyDown = useStore((s) => s.input.setKeyDown);
   const raycaster = useMemo(() => new THREE.Raycaster(), []);
   const ndc = useRef(new THREE.Vector2(0, 0));
 

--- a/src/systems/render/StageLayer.tsx
+++ b/src/systems/render/StageLayer.tsx
@@ -8,8 +8,8 @@ import { useCameraGestures } from "./camera/hooks";
 
 export function StageLayer() {
   const { camera, gl, scene } = useThree();
-  const controlsEnabled = useStore((s) => s.cameraControlsEnabled);
-  const cameraMode = useStore((s) => s.cameraMode);
+  const controlsEnabled = useStore((s) => s.camera.controlsEnabled);
+  const cameraMode = useStore((s) => s.camera.mode);
 
   // Strategy: câmera por modo (memoizada para identidade estável)
   const strategy = useMemo(() => createCameraStrategy(cameraMode), [cameraMode]);

--- a/src/systems/render/camera/hooks.ts
+++ b/src/systems/render/camera/hooks.ts
@@ -11,8 +11,10 @@ export function useRendererSetup(gl: THREE.WebGLRenderer, scene: THREE.Scene) {
 }
 
 export function useCameraGestures(gl: THREE.WebGLRenderer, cameraMode: "persp" | "ortho") {
-  const controlsEnabled = useStore((s: AppState) => s.cameraControlsEnabled);
-  const setCameraGestureActive = useStore((s: AppState) => s.setCameraGestureActive);
+  const controlsEnabled = useStore((s: AppState) => s.camera.controlsEnabled);
+  const setCameraGestureActive = useStore(
+    (s: AppState) => s.camera.setGestureActive,
+  );
   const activeTool = useStore((s: AppState) => s.activeTool);
   const [isSpaceDown, setIsSpaceDown] = useState(false);
   const [isPanDragging, setIsPanDragging] = useState(false);

--- a/src/systems/tools/strategies/BulldozeStrategy.tsx
+++ b/src/systems/tools/strategies/BulldozeStrategy.tsx
@@ -18,8 +18,8 @@ export function createBulldozeStrategy(ctx: ToolContext): ToolStrategy {
   return {
     onActivate() {
       const offPointer = eventBus.on("pointerNdc", ({ x, y }) => {
-        const { activeTool, cameraGestureActive, input } = useStore.getState();
-        if (activeTool !== "bulldoze" || cameraGestureActive) return;
+        const { activeTool, camera, input } = useStore.getState();
+        if (activeTool !== "bulldoze" || camera.gestureActive) return;
         // Raycast primeiro para tentar encontrar objetos
         const ndc = new THREE.Vector2(x, y);
         raycaster.setFromCamera(ndc, ctx.camera);
@@ -43,8 +43,9 @@ export function createBulldozeStrategy(ctx: ToolContext): ToolStrategy {
         }
       });
       const offClick = eventBus.on("click", ({ button, hudTarget }) => {
-        const { activeTool, cameraGestureActive } = useStore.getState();
-        if (activeTool !== "bulldoze" || cameraGestureActive || hudTarget || button !== 0) return;
+        const { activeTool, camera } = useStore.getState();
+        if (activeTool !== "bulldoze" || camera.gestureActive || hudTarget || button !== 0)
+          return;
         const h = state.hover;
         if (!h) return;
         if (h.kind === "object") {

--- a/src/systems/tools/strategies/EyedropperStrategy.tsx
+++ b/src/systems/tools/strategies/EyedropperStrategy.tsx
@@ -9,8 +9,8 @@ export function createEyedropperStrategy(ctx: ToolContext): ToolStrategy {
   return {
     onActivate() {
       const offPointer = eventBus.on("pointerNdc", ({ x, y }) => {
-        const { activeTool, cameraGestureActive } = useStore.getState();
-        if (activeTool !== "eyedropper" || cameraGestureActive) return;
+        const { activeTool, camera } = useStore.getState();
+        if (activeTool !== "eyedropper" || camera.gestureActive) return;
         const ndc = new THREE.Vector2(x, y);
         raycaster.setFromCamera(ndc, ctx.camera);
         const hits = raycaster.intersectObjects(ctx.scene.children, true);
@@ -26,8 +26,9 @@ export function createEyedropperStrategy(ctx: ToolContext): ToolStrategy {
         }
       });
       const offClick = eventBus.on("click", ({ button, hudTarget }) => {
-        const { activeTool, cameraGestureActive } = useStore.getState();
-        if (activeTool !== "eyedropper" || cameraGestureActive || hudTarget || button !== 0) return;
+        const { activeTool, camera } = useStore.getState();
+        if (activeTool !== "eyedropper" || camera.gestureActive || hudTarget || button !== 0)
+          return;
         if (state.hoverDefId) {
           useStore.setState({ selectedCatalogId: state.hoverDefId, activeTool: "place" });
         }

--- a/src/systems/tools/strategies/FloorStrategy.tsx
+++ b/src/systems/tools/strategies/FloorStrategy.tsx
@@ -16,8 +16,8 @@ export function createFloorStrategy(ctx: ToolContext): ToolStrategy {
   return {
     onActivate() {
       const offPointer = eventBus.on("pointerNdc", ({ x, y }) => {
-        const { activeTool, cameraGestureActive, input } = useStore.getState();
-        if (activeTool !== "floor" || cameraGestureActive) return;
+        const { activeTool, camera, input } = useStore.getState();
+        if (activeTool !== "floor" || camera.gestureActive) return;
         const gp = input.groundPoint;
         if (!gp) {
           state.hover = null;
@@ -27,8 +27,9 @@ export function createFloorStrategy(ctx: ToolContext): ToolStrategy {
         state.hover = { x: snapped.x, z: snapped.z };
       });
       const offClick = eventBus.on("click", ({ button, hudTarget }) => {
-        const { activeTool, cameraGestureActive, selectedCatalogId } = useStore.getState();
-        if (activeTool !== "floor" || cameraGestureActive || hudTarget || button !== 0) return;
+        const { activeTool, camera, selectedCatalogId } = useStore.getState();
+        if (activeTool !== "floor" || camera.gestureActive || hudTarget || button !== 0)
+          return;
         const h = state.hover;
         if (!h) return;
         const tile = { x: h.x, z: h.z, tex: selectedCatalogId ?? "floor" };

--- a/src/systems/tools/strategies/MoveStrategy.tsx
+++ b/src/systems/tools/strategies/MoveStrategy.tsx
@@ -23,8 +23,9 @@ export function createMoveStrategy(ctx: ToolContext): ToolStrategy {
   return {
     onActivate() {
       const offDown = eventBus.on("pointerDown", ({ button, hudTarget }) => {
-        const { activeTool, cameraGestureActive, selectedIds } = useStore.getState();
-        if (activeTool !== "move" || cameraGestureActive || hudTarget || button !== 0) return;
+        const { activeTool, camera, selectedIds } = useStore.getState();
+        if (activeTool !== "move" || camera.gestureActive || hudTarget || button !== 0)
+          return;
         if (!selectedIds.length) return;
         const id = selectedIds[0];
         const obj = useStore.getState().objects.find((o) => o.id === id);

--- a/src/systems/tools/strategies/PlaceStrategy.tsx
+++ b/src/systems/tools/strategies/PlaceStrategy.tsx
@@ -41,8 +41,9 @@ export function createPlaceStrategy(ctx: ToolContext): ToolStrategy {
         }
       });
       const offClick = eventBus.on("click", ({ button, hudTarget }) => {
-        const { activeTool, cameraGestureActive, selectedCatalogId } = useStore.getState();
-        if (activeTool !== "place" || hudTarget || cameraGestureActive || button !== 0) return;
+        const { activeTool, camera, selectedCatalogId } = useStore.getState();
+        if (activeTool !== "place" || hudTarget || camera.gestureActive || button !== 0)
+          return;
         const p = state.preview;
         if (!p || !selectedCatalogId || !p.valid) return;
         const id = crypto.randomUUID();

--- a/src/systems/tools/strategies/WallStrategy.tsx
+++ b/src/systems/tools/strategies/WallStrategy.tsx
@@ -55,9 +55,12 @@ export function createWallStrategy(ctx: ToolContext): ToolStrategy {
 
   return {
     onActivate() {
-      const offDown = eventBus.on("pointerDown", ({ button, hudTarget, ground }) => {
-        const { activeTool, cameraGestureActive } = useStore.getState();
-        if (activeTool !== "wall" || cameraGestureActive || hudTarget || button !== 0) return;
+      const offDown = eventBus.on(
+        "pointerDown",
+        ({ button, hudTarget, ground }) => {
+          const { activeTool, camera } = useStore.getState();
+          if (activeTool !== "wall" || camera.gestureActive || hudTarget || button !== 0)
+            return;
         if (!ground) return;
         const snapped = snapToGrid(new THREE.Vector3(ground.x, ground.y, ground.z), "round");
         state.start = snapped;
@@ -65,8 +68,9 @@ export function createWallStrategy(ctx: ToolContext): ToolStrategy {
       });
       const offUp = eventBus.on("pointerUp", ({ button }) => {
         if (button !== 0) return;
-        const { activeTool, cameraGestureActive } = useStore.getState();
-        if (activeTool !== "wall" || cameraGestureActive || !state.start || !state.end) return;
+        const { activeTool, camera } = useStore.getState();
+        if (activeTool !== "wall" || camera.gestureActive || !state.start || !state.end)
+          return;
         const segments = computeSegments(state.start, state.end);
         if (segments.length) {
           const cmd = {
@@ -91,8 +95,8 @@ export function createWallStrategy(ctx: ToolContext): ToolStrategy {
       state.end = null;
     },
     onFrame() {
-      const { activeTool, cameraGestureActive, input } = useStore.getState();
-      if (activeTool !== "wall" || cameraGestureActive || !state.start) return;
+      const { activeTool, camera, input } = useStore.getState();
+      if (activeTool !== "wall" || camera.gestureActive || !state.start) return;
       const gp = input.groundPoint;
       if (!gp) return;
       const snapped = snapToGrid(new THREE.Vector3(gp.x, gp.y, gp.z), "round");

--- a/src/ui/hud/Topbar/CameraModeToggle.tsx
+++ b/src/ui/hud/Topbar/CameraModeToggle.tsx
@@ -4,8 +4,8 @@ import { MdOutlineViewInAr } from "react-icons/md";
 import { LuRotate3D } from "react-icons/lu";
 
 export function CameraModeToggle() {
-  const cameraMode = useStore((s) => s.cameraMode);
-  const setCameraMode = useStore((s) => s.setCameraMode);
+  const cameraMode = useStore((s) => s.camera.mode);
+  const setCameraMode = useStore((s) => s.camera.setMode);
   return (
     <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
       <Button


### PR DESCRIPTION
## Summary
- split camera state into dedicated cameraSlice with nested actions
- move input handling to its own inputSlice
- update store composition and usages across project

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68996e20adb88325808bf85e2487c8f2