### PR TITLE
refactor: split place tool strategy

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,12 +7,13 @@ import { WallsLayer } from "../systems/render/WallsLayer";
 import { FloorLayer } from "../systems/render/FloorLayer";
 import { HudRoot } from "../ui/hud";
 import { ToolManager } from "../systems/tools/ToolManager";
-import { createPlaceStrategy } from "../systems/tools/strategies/PlaceStrategy";
+import { PlaceStrategy } from "../systems/tools/strategies/PlaceStrategy";
 import { createMoveStrategy } from "../systems/tools/strategies/MoveStrategy";
 import { createWallStrategy } from "../systems/tools/strategies/WallStrategy";
 import { createFloorStrategy } from "../systems/tools/strategies/FloorStrategy";
 import { createBulldozeStrategy } from "../systems/tools/strategies/BulldozeStrategy";
 import { createEyedropperStrategy } from "../systems/tools/strategies/EyedropperStrategy";
+import { strategyComponentFactory } from "../systems/tools/strategies/strategyComponentFactory";
 import { SelectedInspector } from "../ui/inworld/Inspector";
 import { InputController } from "../systems/controllers/InputController";
 import { Perf } from "r3f-perf";
@@ -36,12 +37,12 @@ export function App() {
           <SelectedInspector />
           <ToolManager
             strategies={{
-              place: (ctx) => createPlaceStrategy(ctx),
-              move: (ctx) => createMoveStrategy(ctx),
-              wall: (ctx) => createWallStrategy(ctx),
-              floor: (ctx) => createFloorStrategy(ctx),
-              bulldoze: (ctx) => createBulldozeStrategy(ctx),
-              eyedropper: (ctx) => createEyedropperStrategy(ctx),
+              place: PlaceStrategy,
+              move: strategyComponentFactory(createMoveStrategy),
+              wall: strategyComponentFactory(createWallStrategy),
+              floor: strategyComponentFactory(createFloorStrategy),
+              bulldoze: strategyComponentFactory(createBulldozeStrategy),
+              eyedropper: strategyComponentFactory(createEyedropperStrategy),
             }}
           />
         </Suspense>

--- a/src/systems/tools/strategies/PlaceStrategy.tsx
+++ b/src/systems/tools/strategies/PlaceStrategy.tsx
@@ -1,177 +1,33 @@
-import React from "react";
-import * as THREE from "three";
-import { useStore } from "../../../store/useStore";
-import { ToolStrategy, ToolContext } from "./types";
-import { catalog } from "../../../core/catalog";
-import { snapToGrid } from "../toolUtils";
-import { eventBus } from "../../../core/events";
-import { executeCommand } from "../../../core/commandStack";
-import { withBudget } from "../../../core/budget";
-import { validatePlacement } from "../../../core/placement";
-import { aabbIntersects } from "../../../core/geometry";
-import { CatalogItem3D, PlacedObject3D } from "../../../core/types";
-import { buildObjectAabbIndex } from "../../../core/sceneIndex";
+import { useState } from "react";
+import { ToolContext } from "./types";
+import { usePlacementPreview } from "./placePreview";
+import { usePlaceEvents } from "./placeEvents";
 
-export function createPlaceStrategy(ctx: ToolContext): ToolStrategy {
-  const state = {
-    preview: null as null | {
-      pos: THREE.Vector3;
-      w: number;
-      h: number;
-      d: number;
-      color: string;
-      yawDeg?: 0 | 90 | 180 | 270;
-      valid?: boolean;
-    },
-    yaw: 0 as 0 | 90 | 180 | 270,
-    cleanup: [] as Array<() => void>,
-    index: null as ReturnType<typeof buildObjectAabbIndex> | null,
-    lastObjectsRef: null as PlacedObject3D[] | null,
-  };
-
-  const api: ToolStrategy = {
-    onActivate() {
-      const offKeyDown = eventBus.on("keyDown", ({ code, shift }) => {
-        if (code.toLowerCase?.() === "keyr" || code === "KeyR") {
-          state.yaw = (((state.yaw ?? 0) + (shift ? 270 : 90)) % 360) as 0 | 90 | 180 | 270;
-        }
-        if (code === "Escape") {
-          useStore.setState({ selectedCatalogId: undefined });
-          state.preview = null;
-        }
-      });
-      const offClick = eventBus.on("click", ({ button, hudTarget }) => {
-        const { activeTool, camera, selectedCatalogId } = useStore.getState();
-        if (activeTool !== "place" || hudTarget || camera.gestureActive || button !== 0)
-          return;
-        const p = state.preview;
-        if (!p || !selectedCatalogId || !p.valid) return;
-        const id = crypto.randomUUID();
-        // Command pattern
-        const cmd = {
-          description: "place-object",
-          execute: () =>
-            useStore.setState((s) => ({
-              objects: [
-                ...s.objects,
-                {
-                  id,
-                  defId: selectedCatalogId,
-                  pos: { x: p.pos.x, y: 0, z: p.pos.z },
-                  rot: { x: 0, y: state.yaw ?? 0, z: 0 },
-                },
-              ],
-            })),
-          undo: () => useStore.setState((s) => ({ objects: s.objects.filter((o) => o.id !== id) })),
-        };
-        const price =
-          (catalog as unknown as CatalogItem3D[]).find((i) => i.id === selectedCatalogId)?.price ??
-          0;
-        const decorated = withBudget(cmd, price);
-        executeCommand(decorated, useStore.getState().pushCommand);
-      });
-      state.cleanup.push(offKeyDown, offClick);
-    },
-    onDeactivate() {
-      state.cleanup.forEach((fn) => fn());
-      state.cleanup = [];
-      state.preview = null;
-    },
-    onFrame() {
-      const { activeTool, selectedCatalogId, objects, lot, input } = useStore.getState();
-      if (activeTool !== "place" || !selectedCatalogId) {
-        state.preview = null;
-        return;
-      }
-      const gp = input.groundPoint;
-      if (!gp) {
-        state.preview = null;
-        return;
-      }
-      const catalogItems = catalog as unknown as CatalogItem3D[];
-      const item = catalogItems.find((i) => i.id === selectedCatalogId);
-      if (!item) {
-        state.preview = null;
-        return;
-      }
-      const fp = item.footprint;
-      let baseW = 1;
-      let baseD = 1;
-      let baseH = 1;
-      if (fp && fp.kind === "box") {
-        baseW = fp.w;
-        baseD = fp.d;
-        baseH = fp.h;
-      }
-      const yaw = state.yaw;
-      const rotW = yaw % 180 === 0 ? baseW : baseD;
-      const rotD = yaw % 180 === 0 ? baseD : baseW;
-      const pos = snapToGrid(new THREE.Vector3(gp.x, gp.y, gp.z), "floor");
-
-      // Reconstruir índice apenas quando o array de objetos mudar (referência)
-      if (state.lastObjectsRef !== objects) {
-        state.index = buildObjectAabbIndex(objects, catalogItems);
-        state.lastObjectsRef = objects;
-      }
-
-      // Checagem rápida via índice espacial
-      const candidate = {
-        min: { x: pos.x, y: 0, z: pos.z },
-        max: { x: pos.x + rotW, y: baseH, z: pos.z + rotD },
-      };
-      let fastOk = true;
-      const neighbors = state.index ? state.index.query(candidate) : [];
-      for (const b of neighbors) {
-        if (aabbIntersects(candidate, b)) {
-          fastOk = false;
-          break;
-        }
-      }
-
-      const valid =
-        fastOk &&
-        validatePlacement(
-          { ...item, footprint: { w: rotW, d: rotD, h: baseH, kind: "box" } },
-          { x: pos.x, y: 0, z: pos.z },
-          { x: 0, y: state.yaw, z: 0 },
-          objects,
-          [],
-          { width: lot.width, depth: lot.depth },
-          catalogItems,
-        ).ok;
-      state.preview = {
-        pos,
-        w: rotW,
-        d: rotD,
-        h: baseH,
-        color: item.art?.color ?? "#64748b",
-        yawDeg: yaw,
-        valid,
-      };
-    },
-    renderPreview() {
-      const p = state.preview;
-      if (!p) return null;
-      return (
-        <mesh
-          position={[p.pos.x + p.w / 2, p.h / 2, p.pos.z + p.d / 2]}
-          renderOrder={1000}
-          castShadow={false}
-          receiveShadow={false}
-        >
-          <boxGeometry args={[p.w, p.h, p.d]} />
-          <meshStandardMaterial
-            color={p.valid ? "#16a34a" : "#ef4444"}
-            transparent
-            opacity={0.5}
-            depthTest={false}
-            depthWrite={false}
-            polygonOffset
-            polygonOffsetFactor={-1}
-          />
-        </mesh>
-      );
-    },
-  };
-  return api;
+export function PlaceStrategy({ ctx }: { ctx: ToolContext }) {
+  void ctx;
+  const [yaw, setYaw] = useState<0 | 90 | 180 | 270>(0);
+  const preview = usePlacementPreview(yaw);
+  usePlaceEvents(yaw, setYaw, preview);
+  if (!preview) return null;
+  return (
+    <mesh
+      position={[preview.pos.x + preview.w / 2, preview.h / 2, preview.pos.z + preview.d / 2]}
+      renderOrder={1000}
+      castShadow={false}
+      receiveShadow={false}
+    >
+      <boxGeometry args={[preview.w, preview.h, preview.d]} />
+      <meshStandardMaterial
+        color={preview.valid ? "#16a34a" : "#ef4444"}
+        transparent
+        opacity={0.5}
+        depthTest={false}
+        depthWrite={false}
+        polygonOffset
+        polygonOffsetFactor={-1}
+      />
+    </mesh>
+  );
 }
+
+export default PlaceStrategy;

--- a/src/systems/tools/strategies/placeCommand.ts
+++ b/src/systems/tools/strategies/placeCommand.ts
@@ -1,0 +1,32 @@
+import * as THREE from "three";
+import { catalog } from "../../../core/catalog";
+import { withBudget } from "../../../core/budget";
+import { executeCommand } from "../../../core/commandStack";
+import { useStore } from "../../../store/useStore";
+import { CatalogItem3D } from "../../../core/types";
+
+export function createPlaceCommand(defId: string, pos: THREE.Vector3, yaw: 0 | 90 | 180 | 270) {
+  const id = crypto.randomUUID();
+  const cmd = {
+    description: "place-object",
+    execute: () =>
+      useStore.setState((s) => ({
+        objects: [
+          ...s.objects,
+          {
+            id,
+            defId,
+            pos: { x: pos.x, y: 0, z: pos.z },
+            rot: { x: 0, y: yaw, z: 0 },
+          },
+        ],
+      })),
+    undo: () =>
+      useStore.setState((s) => ({ objects: s.objects.filter((o) => o.id !== id) })),
+  };
+  const price =
+    (catalog as unknown as CatalogItem3D[]).find((i) => i.id === defId)?.price ?? 0;
+  const decorated = withBudget(cmd, price);
+  executeCommand(decorated, useStore.getState().pushCommand);
+}
+

--- a/src/systems/tools/strategies/placeEvents.ts
+++ b/src/systems/tools/strategies/placeEvents.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { eventBus } from "../../../core/events";
+import { useStore } from "../../../store/useStore";
+import { createPlaceCommand } from "./placeCommand";
+import type { PlacementPreview } from "./placePreview";
+
+export function usePlaceEvents(
+  yaw: 0 | 90 | 180 | 270,
+  setYaw: (y: 0 | 90 | 180 | 270) => void,
+  preview: PlacementPreview | null,
+) {
+  useEffect(() => {
+    const offKeyDown = eventBus.on("keyDown", ({ code, shift }) => {
+      if (code.toLowerCase?.() === "keyr" || code === "KeyR") {
+        setYaw(((yaw + (shift ? 270 : 90)) % 360) as 0 | 90 | 180 | 270);
+      }
+      if (code === "Escape") {
+        useStore.setState({ selectedCatalogId: undefined });
+      }
+    });
+    const offClick = eventBus.on("click", ({ button, hudTarget }) => {
+      const { activeTool, cameraGestureActive, selectedCatalogId } = useStore.getState();
+      if (activeTool !== "place" || hudTarget || cameraGestureActive || button !== 0) return;
+      if (!preview || !selectedCatalogId || !preview.valid) return;
+      createPlaceCommand(selectedCatalogId, preview.pos, yaw);
+    });
+    return () => {
+      offKeyDown();
+      offClick();
+    };
+  }, [yaw, setYaw, preview]);
+}
+

--- a/src/systems/tools/strategies/placePreview.ts
+++ b/src/systems/tools/strategies/placePreview.ts
@@ -1,0 +1,100 @@
+import { useRef, useState } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+import { snapToGrid } from "../toolUtils";
+import { useStore } from "../../../store/useStore";
+import { catalog } from "../../../core/catalog";
+import { validatePlacement } from "../../../core/placement";
+import { aabbIntersects } from "../../../core/geometry";
+import { CatalogItem3D, PlacedObject3D } from "../../../core/types";
+import { buildObjectAabbIndex } from "../../../core/sceneIndex";
+
+export interface PlacementPreview {
+  pos: THREE.Vector3;
+  w: number;
+  h: number;
+  d: number;
+  color: string;
+  yawDeg?: 0 | 90 | 180 | 270;
+  valid?: boolean;
+}
+
+export function usePlacementPreview(yaw: 0 | 90 | 180 | 270) {
+  const [preview, setPreview] = useState<PlacementPreview | null>(null);
+  const indexRef = useRef<ReturnType<typeof buildObjectAabbIndex> | null>(null);
+  const lastObjectsRef = useRef<PlacedObject3D[] | null>(null);
+
+  useFrame(() => {
+    const { activeTool, selectedCatalogId, objects, lot, input } = useStore.getState();
+    if (activeTool !== "place" || !selectedCatalogId) {
+      if (preview) setPreview(null);
+      return;
+    }
+    const gp = input.groundPoint;
+    if (!gp) {
+      if (preview) setPreview(null);
+      return;
+    }
+    const catalogItems = catalog as unknown as CatalogItem3D[];
+    const item = catalogItems.find((i) => i.id === selectedCatalogId);
+    if (!item) {
+      if (preview) setPreview(null);
+      return;
+    }
+    const fp = item.footprint;
+    let baseW = 1;
+    let baseD = 1;
+    let baseH = 1;
+    if (fp && fp.kind === "box") {
+      baseW = fp.w;
+      baseD = fp.d;
+      baseH = fp.h;
+    }
+    const rotW = yaw % 180 === 0 ? baseW : baseD;
+    const rotD = yaw % 180 === 0 ? baseD : baseW;
+    const pos = snapToGrid(new THREE.Vector3(gp.x, gp.y, gp.z), "floor");
+
+    if (lastObjectsRef.current !== objects) {
+      indexRef.current = buildObjectAabbIndex(objects, catalogItems);
+      lastObjectsRef.current = objects;
+    }
+
+    const candidate = {
+      min: { x: pos.x, y: 0, z: pos.z },
+      max: { x: pos.x + rotW, y: baseH, z: pos.z + rotD },
+    };
+    let fastOk = true;
+    const neighbors = indexRef.current ? indexRef.current.query(candidate) : [];
+    for (const b of neighbors) {
+      if (aabbIntersects(candidate, b)) {
+        fastOk = false;
+        break;
+      }
+    }
+
+    const valid =
+      fastOk &&
+      validatePlacement(
+        { ...item, footprint: { w: rotW, d: rotD, h: baseH, kind: "box" } },
+        { x: pos.x, y: 0, z: pos.z },
+        { x: 0, y: yaw, z: 0 },
+        objects,
+        [],
+        { width: lot.width, depth: lot.depth },
+        catalogItems,
+      ).ok;
+
+    setPreview({
+      pos,
+      w: rotW,
+      d: rotD,
+      h: baseH,
+      color: item.art?.color ?? "#64748b",
+      yawDeg: yaw,
+      valid,
+    });
+  });
+
+  return preview;
+}
+

--- a/src/systems/tools/strategies/strategyComponentFactory.tsx
+++ b/src/systems/tools/strategies/strategyComponentFactory.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { ToolContext } from "./types";
+import type { ToolStrategy } from "./types";
+
+export function strategyComponentFactory(create: (ctx: ToolContext) => ToolStrategy) {
+  return function StrategyComponent({ ctx }: { ctx: ToolContext }) {
+    const strategyRef = useRef<ToolStrategy | null>(null);
+    const cleanupRef = useRef<(() => void) | undefined>(undefined);
+
+    useEffect(() => {
+      strategyRef.current = create(ctx);
+      cleanupRef.current = strategyRef.current.onActivate?.() as (() => void) | undefined;
+      return () => {
+        if (typeof cleanupRef.current === "function") cleanupRef.current();
+        strategyRef.current?.onDeactivate?.();
+      };
+    }, [ctx]);
+
+    useFrame(() => {
+      strategyRef.current?.onFrame?.();
+    });
+
+    return strategyRef.current?.renderPreview() ?? null;
+  };
+}
+
+export default strategyComponentFactory;

--- a/src/systems/tools/strategies/types.ts
+++ b/src/systems/tools/strategies/types.ts
@@ -8,8 +8,10 @@ export type ToolContext = {
 };
 
 export interface ToolStrategy {
-  onActivate(ctx: ToolContext): void | (() => void);
+  onActivate(): void | (() => void);
   onDeactivate(): void;
   onFrame?(): void;
   renderPreview(): ReactNode | null;
 }
+
+export type StrategyComponent = (props: { ctx: ToolContext }) => ReactNode | null;


### PR DESCRIPTION
## Summary
- split place tool into hooks for preview, events, and command
- add usePlacementPreview hook and component-based ToolManager
- wrap existing strategies with strategyComponentFactory

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68996e73e8a08325991497be7beb425e