### PR TITLE
Add Lot3D schema validation

### DIFF
--- a/src/core/serialization.ts
+++ b/src/core/serialization.ts
@@ -1,8 +1,48 @@
-export function exportLot<T>(lot: T, version: number = 1): string {
+import { z } from "zod";
+
+const Vec3Schema = z.object({ x: z.number(), y: z.number(), z: z.number() });
+
+const PlacedObject3DSchema = z.object({
+  id: z.string(),
+  defId: z.string(),
+  pos: Vec3Schema,
+  rot: Vec3Schema,
+  variant: z.string().optional(),
+});
+
+const WallSegment3DSchema = z.object({
+  ax: z.number(),
+  ay: z.number(),
+  az: z.number(),
+  bx: z.number(),
+  by: z.number(),
+  bz: z.number(),
+});
+
+const FloorTile3DSchema = z.object({
+  x: z.number(),
+  z: z.number(),
+  tex: z.string(),
+});
+
+const BudgetSchema = z.object({ funds: z.number(), spent: z.number() });
+
+export const Lot3DSchema = z.object({
+  width: z.number(),
+  depth: z.number(),
+  height: z.number(),
+  objects: z.array(PlacedObject3DSchema),
+  walls: z.array(WallSegment3DSchema),
+  floor: z.array(FloorTile3DSchema),
+  budget: BudgetSchema,
+  version: z.number(),
+});
+
+export function exportLot(lot: z.infer<typeof Lot3DSchema>, version: number = 1): string {
   return JSON.stringify({ version, lot }, null, 2);
 }
 
-export function importLot<T>(json: string): { version: number; lot: T } {
+export function importLot(json: string): { version: number; lot: unknown } {
   const parsed = JSON.parse(json);
   if (typeof parsed.version !== "number") throw new Error("Versão inválida");
   return parsed;

--- a/src/ui/services/fileActions.ts
+++ b/src/ui/services/fileActions.ts
@@ -1,4 +1,4 @@
-import { exportLot, importLot } from "../../core/serialization";
+import { exportLot, importLot, Lot3DSchema } from "../../core/serialization";
 import { useStore } from "../../store/useStore";
 
 export function exportCurrentLotToDownload(): void {
@@ -24,8 +24,8 @@ export function exportCurrentLotToDownload(): void {
 
 export async function importLotFromFile(file: File): Promise<void> {
   const text = await file.text();
-  const parsed = importLot<any>(text);
-  const lot = parsed.lot as any;
+  const parsed = importLot(text);
+  const lot = Lot3DSchema.parse(parsed.lot);
   useStore.setState({
     lot: { width: lot.width, depth: lot.depth, height: lot.height },
     objects: lot.objects ?? [],


### PR DESCRIPTION
## Summary
- add Zod schemas for Lot3D serialization
- validate imported lot files against Lot3DSchema

## Testing
- `npm run lint` *(fails: Unknown property 'receiveShadow' found, etc.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a9b97904483258fe5e80483cefdf8