### PR TITLE
feat: implement ToolComponent

### DIFF
--- a/src/core/types/components/ToolComponent.ts
+++ b/src/core/types/components/ToolComponent.ts
@@ -1,0 +1,52 @@
+import type { Component } from "@core/types/Component";
+import type { ToolType, ModeType } from "@core/types";
+
+/**
+ * Interface para componente de ferramenta
+ *
+ * Armazena a ferramenta e modo de operação ativos
+ */
+export interface ToolComponent extends Component {
+    readonly type: "ToolComponent";
+
+    /**
+     * Ferramenta ativa
+     */
+    readonly tool: ToolType;
+
+    /**
+     * Modo de operação ativo
+     */
+    readonly mode: ModeType;
+
+    /**
+     * Define a ferramenta ativa
+     */
+    setTool(tool: ToolType): ToolComponent;
+
+    /**
+     * Define o modo ativo
+     */
+    setMode(mode: ModeType): ToolComponent;
+
+    /**
+     * Verifica se os dados são válidos
+     */
+    isValid(): boolean;
+}
+
+/**
+ * Dados para criar um ToolComponent
+ */
+export interface ToolComponentData {
+    tool?: ToolType;
+    mode?: ModeType;
+}
+
+/**
+ * Configuração padrão para ToolComponent
+ */
+export const DEFAULT_TOOL: Required<ToolComponentData> = {
+    tool: "view",
+    mode: "view",
+};

--- a/src/core/types/components/index.ts
+++ b/src/core/types/components/index.ts
@@ -18,3 +18,9 @@ export type {
     PhysicsComponentData,
     DEFAULT_PHYSICS,
 } from "./PhysicsComponent";
+
+export type {
+    ToolComponent,
+    ToolComponentData,
+    DEFAULT_TOOL,
+} from "./ToolComponent";

--- a/src/domain/components/ToolComponent.ts
+++ b/src/domain/components/ToolComponent.ts
@@ -1,0 +1,87 @@
+import type { ValidationResult } from "@core/types/Component";
+import type {
+    ToolComponent as IToolComponent,
+    ToolComponentData,
+} from "@core/types/components/ToolComponent";
+import type { ToolType, ModeType } from "@core/types";
+import { BaseComponent } from "@domain/components";
+import { DEFAULT_TOOL } from "@core/types/components/ToolComponent";
+
+/**
+ * Componente de estado de ferramenta
+ *
+ * Armazena a ferramenta e o modo de operação atuais.
+ * Todas as modificações retornam uma nova instância para manter imutabilidade.
+ */
+export class ToolComponent extends BaseComponent implements IToolComponent {
+    public readonly type = "ToolComponent";
+
+    public readonly tool: ToolType;
+    public readonly mode: ModeType;
+
+    constructor(data: ToolComponentData = {}) {
+        super("ToolComponent");
+        this.tool = data.tool ?? DEFAULT_TOOL.tool;
+        this.mode = data.mode ?? DEFAULT_TOOL.mode;
+    }
+
+    /** Define a ferramenta ativa */
+    public setTool(tool: ToolType): ToolComponent {
+        return this.withChanges({ tool });
+    }
+
+    /** Define o modo ativo */
+    public setMode(mode: ModeType): ToolComponent {
+        return this.withChanges({ mode });
+    }
+
+    /** Verifica se os dados do componente são válidos */
+    public isValid(): boolean {
+        const validation = this.validate();
+        return validation.isValid;
+    }
+
+    /** Validação específica do ToolComponent */
+    public override validate(): ValidationResult {
+        const baseValidation = super.validate();
+        const errors: string[] = [...baseValidation.errors];
+        const warnings: string[] = [...(baseValidation.warnings || [])];
+
+        if (typeof this.tool !== "string" || this.tool.trim() === "") {
+            errors.push("Ferramenta inválida");
+        }
+
+        if (typeof this.mode !== "string" || this.mode.trim() === "") {
+            errors.push("Modo inválido");
+        }
+
+        return {
+            isValid: errors.length === 0,
+            errors,
+            ...(warnings.length > 0 ? { warnings } : {}),
+        };
+    }
+
+    /** Cria uma cópia do componente */
+    public override clone(): ToolComponent {
+        return this.withChanges({});
+    }
+
+    /** Verifica se dois ToolComponents são iguais */
+    public override equals(other: ToolComponent): boolean {
+        return super.equals(other) && this.tool === other.tool && this.mode === other.mode;
+    }
+
+    /** Converte o componente para string */
+    public override toString(): string {
+        return `ToolComponent(tool:${this.tool}, mode:${this.mode})`;
+    }
+
+    /** Cria nova instância com mudanças específicas */
+    private withChanges(changes: Partial<ToolComponentData>): ToolComponent {
+        return new ToolComponent({
+            tool: changes.tool ?? this.tool,
+            mode: changes.mode ?? this.mode,
+        });
+    }
+}

--- a/src/domain/components/index.ts
+++ b/src/domain/components/index.ts
@@ -25,3 +25,6 @@ export type { RenderComponentData, MaterialConfig } from "@core/types/components
 
 export { PhysicsComponent } from "./PhysicsComponent";
 export type { PhysicsComponentData } from "@core/types/components/PhysicsComponent";
+
+export { ToolComponent } from "./ToolComponent";
+export type { ToolComponentData } from "@core/types/components/ToolComponent";

--- a/tests/unit/components/ToolComponent.test.ts
+++ b/tests/unit/components/ToolComponent.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { ToolComponent } from "@domain/components";
+import type { ToolType } from "@core/types";
+
+describe("ToolComponent", () => {
+    describe("Criação", () => {
+        it("deve criar ToolComponent com valores padrão", () => {
+            const component = new ToolComponent();
+
+            expect(component.type).toBe("ToolComponent");
+            expect(component.tool).toBe("view");
+            expect(component.mode).toBe("view");
+        });
+
+        it("deve criar ToolComponent com dados customizados", () => {
+            const component = new ToolComponent({ tool: "move", mode: "build" });
+
+            expect(component.tool).toBe("move");
+            expect(component.mode).toBe("build");
+        });
+    });
+
+    describe("Métodos de modificação", () => {
+        it("deve definir a ferramenta", () => {
+            const component = new ToolComponent();
+            const newComponent = component.setTool("select");
+
+            expect(newComponent.tool).toBe("select");
+            expect(newComponent).not.toBe(component);
+        });
+
+        it("deve definir o modo", () => {
+            const component = new ToolComponent();
+            const newComponent = component.setMode("buy");
+
+            expect(newComponent.mode).toBe("buy");
+            expect(newComponent).not.toBe(component);
+        });
+    });
+
+    describe("Validação", () => {
+        it("deve detectar ferramenta inválida", () => {
+            const invalid = new ToolComponent({ tool: "" as ToolType });
+            expect(invalid.isValid()).toBe(false);
+        });
+    });
+
+    describe("Utilitários", () => {
+        it("deve verificar igualdade", () => {
+            const c1 = new ToolComponent({ tool: "move", mode: "build" });
+            const c2 = new ToolComponent({ tool: "move", mode: "build" });
+            const c3 = new ToolComponent({ tool: "delete", mode: "build" });
+
+            expect(c1.equals(c2)).toBe(true);
+            expect(c1.equals(c3)).toBe(false);
+        });
+
+        it("deve clonar componente", () => {
+            const component = new ToolComponent({ tool: "wall", mode: "build" });
+            const clone = component.clone();
+
+            expect(clone).not.toBe(component);
+            expect(clone.tool).toBe("wall");
+            expect(clone.mode).toBe("build");
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add ToolComponent core types and defaults
- implement ToolComponent domain class with validation and helpers
- cover ToolComponent behavior with unit tests

## Testing
- `pnpm lint`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68a65186ac0483259195efb83f3f5cd5