### PR TITLE
feat: implementar SceneManager

### DIFF
--- a/src/core/types/scene/SceneManager.ts
+++ b/src/core/types/scene/SceneManager.ts
@@ -1,0 +1,22 @@
+import type { Scene } from "three";
+import type { EventBus } from "@core/events/EventBus";
+
+/**
+ * Identificador único de cena
+ */
+export type SceneId = string;
+
+/**
+ * Dependências do SceneManager
+ */
+export interface SceneManagerDependencies {
+    /**
+     * EventBus para emissão de eventos do sistema
+     */
+    eventBus: EventBus;
+
+    /**
+     * Factory para criação de cenas
+     */
+    createScene?: () => Scene;
+}

--- a/src/core/types/scene/index.ts
+++ b/src/core/types/scene/index.ts
@@ -3,3 +3,7 @@
  */
 
 export type { SceneAction } from "./SceneTypes";
+export type {
+    SceneId,
+    SceneManagerDependencies,
+} from "./SceneManager";

--- a/src/infrastructure/render/SceneManager.ts
+++ b/src/infrastructure/render/SceneManager.ts
@@ -1,0 +1,110 @@
+import { Scene } from "three";
+import type { SceneId, SceneManagerDependencies } from "@core/types/scene";
+import type { EventBus } from "@core/events/EventBus";
+
+/**
+ * Gerenciador de cenas Three.js
+ *
+ * Responsável por criar, armazenar e alternar entre cenas.
+ */
+export class SceneManager {
+    private static instance: SceneManager | null = null;
+    private readonly scenes: Map<SceneId, Scene> = new Map();
+    private readonly eventBus: EventBus;
+    private readonly sceneFactory: () => Scene;
+    private activeSceneId: SceneId | null = null;
+
+    private constructor(deps: SceneManagerDependencies) {
+        this.eventBus = deps.eventBus;
+        this.sceneFactory = deps.createScene ?? ((): Scene => new Scene());
+    }
+
+    /**
+     * Obtém a instância singleton do SceneManager
+     */
+    public static getInstance(deps: SceneManagerDependencies): SceneManager {
+        if (!SceneManager.instance) {
+            SceneManager.instance = new SceneManager(deps);
+        }
+        return SceneManager.instance;
+    }
+
+    /**
+     * Reseta a instância singleton (apenas para testes)
+     */
+    public static resetInstance(): void {
+        SceneManager.instance = null;
+    }
+
+    /**
+     * Cria uma nova cena e a define como ativa
+     */
+    public createScene(id: SceneId): Scene {
+        if (this.scenes.has(id)) {
+            throw new Error(`Cena com ID ${id} já existe`);
+        }
+
+        const scene = this.sceneFactory();
+        this.scenes.set(id, scene);
+        this.setActiveScene(id);
+        return scene;
+    }
+
+    /**
+     * Define a cena ativa
+     */
+    public setActiveScene(id: SceneId): void {
+        if (!this.scenes.has(id)) {
+            throw new Error(`Cena com ID ${id} não existe`);
+        }
+        this.activeSceneId = id;
+        this.eventBus.emit("sceneStateChanged", { action: "loaded", sceneId: id });
+    }
+
+    /**
+     * Obtém a cena ativa
+     */
+    public getActiveScene(): Scene | undefined {
+        return this.activeSceneId ? this.scenes.get(this.activeSceneId) : undefined;
+    }
+
+    /**
+     * Obtém uma cena pelo ID
+     */
+    public getScene(id: SceneId): Scene | undefined {
+        return this.scenes.get(id);
+    }
+
+    /**
+     * Verifica se uma cena existe
+     */
+    public hasScene(id: SceneId): boolean {
+        return this.scenes.has(id);
+    }
+
+    /**
+     * Remove uma cena
+     */
+    public removeScene(id: SceneId): boolean {
+        const removed = this.scenes.delete(id);
+        if (removed && this.activeSceneId === id) {
+            this.activeSceneId = null;
+        }
+        return removed;
+    }
+
+    /**
+     * Número de cenas registradas
+     */
+    public getSceneCount(): number {
+        return this.scenes.size;
+    }
+
+    /**
+     * Remove todas as cenas
+     */
+    public clearScenes(): void {
+        this.scenes.clear();
+        this.activeSceneId = null;
+    }
+}

--- a/src/infrastructure/render/index.ts
+++ b/src/infrastructure/render/index.ts
@@ -1,2 +1,3 @@
 export { RenderSystem } from "./RenderSystem";
 export { RenderObjectManager, type RenderObject } from "./RenderObjectManager";
+export { SceneManager } from "./SceneManager";

--- a/tests/unit/render/SceneManager.test.ts
+++ b/tests/unit/render/SceneManager.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { SceneManager } from "@infrastructure/render";
+import { EventBus } from "@core/events/EventBus";
+
+describe("SceneManager", () => {
+    beforeEach(() => {
+        SceneManager.resetInstance();
+    });
+
+    it("deve ser singleton", () => {
+        const deps = { eventBus: new EventBus() };
+        const manager1 = SceneManager.getInstance(deps);
+        const manager2 = SceneManager.getInstance(deps);
+        expect(manager1).toBe(manager2);
+    });
+
+    it("deve criar e definir cena ativa", () => {
+        const eventBus = new EventBus();
+        const listener = vi.fn();
+        eventBus.on("sceneStateChanged", listener);
+        const manager = SceneManager.getInstance({ eventBus });
+
+        const scene = manager.createScene("scene1");
+        expect(scene).toBeDefined();
+        expect(manager.getActiveScene()).toBe(scene);
+        expect(listener).toHaveBeenCalledWith({ action: "loaded", sceneId: "scene1" });
+    });
+
+    it("deve alternar cena ativa", () => {
+        const eventBus = new EventBus();
+        const listener = vi.fn();
+        eventBus.on("sceneStateChanged", listener);
+        const manager = SceneManager.getInstance({ eventBus });
+
+        const scene1 = manager.createScene("scene1");
+        const scene2 = manager.createScene("scene2");
+        manager.setActiveScene("scene1");
+        expect(manager.getActiveScene()).toBe(scene1);
+        manager.setActiveScene("scene2");
+        expect(manager.getActiveScene()).toBe(scene2);
+        expect(listener).toHaveBeenCalledTimes(4); // createScene emite 2 vezes + 2 chamadas de setActiveScene
+    });
+
+    it("deve remover cena", () => {
+        const manager = SceneManager.getInstance({ eventBus: new EventBus() });
+        manager.createScene("scene1");
+        expect(manager.removeScene("scene1")).toBe(true);
+        expect(manager.hasScene("scene1")).toBe(false);
+    });
+
+    it("deve limpar todas as cenas", () => {
+        const manager = SceneManager.getInstance({ eventBus: new EventBus() });
+        manager.createScene("scene1");
+        manager.createScene("scene2");
+        expect(manager.getSceneCount()).toBe(2);
+        manager.clearScenes();
+        expect(manager.getSceneCount()).toBe(0);
+        expect(manager.getActiveScene()).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- add SceneManager core types and implementation
- expose SceneManager through render layer
- test SceneManager creation, switching and cleanup
- simplify SceneManager API by removing config and implicit scene creation

## Testing
- `pnpm lint`
- `pnpm vitest --run`
- `npx -y madge --circular src --extensions ts,tsx --ts-config tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68aa57c0844883259a04133f1806c597