### PR TITLE
refactor: isolate layer items

### DIFF
--- a/src/presentation/layers/FloorItem.tsx
+++ b/src/presentation/layers/FloorItem.tsx
@@ -1,0 +1,63 @@
+import type { JSX } from "react";
+import { useApplication } from "@presentation/hooks/useApplication";
+import type { EntityId } from "@core/types/ecs/EntityId";
+import type { FloorComponent as IFloorComponent } from "@core/types/components/FloorComponent";
+import type { RenderComponent as IRenderComponent } from "@core/types/components/RenderComponent";
+
+/**
+ * Item responsável por renderizar um piso e emitir eventos de interação.
+ */
+export function FloorItem({
+    entityId,
+    floor,
+    color,
+}: {
+    readonly entityId: EntityId;
+    readonly floor: IFloorComponent;
+    readonly color: string;
+}): JSX.Element {
+    const { eventBus, entityManager } = useApplication();
+
+    const position: [number, number, number] = [
+        floor.position.x,
+        floor.position.y + floor.size.y / 2,
+        floor.position.z,
+    ];
+    const scale: [number, number, number] = [
+        floor.size.x,
+        floor.size.y,
+        floor.size.z,
+    ];
+
+    const rc = entityManager
+        .getEntity(entityId)
+        ?.getComponent<IRenderComponent>("RenderComponent");
+    const colorToUse = rc?.color ?? color;
+
+    function handleDown(): void {
+        eventBus.emit("entitySelected", { entityId });
+    }
+    function handleOver(): void {
+        eventBus.emit("entityHovered", { entityId });
+    }
+    function handleOut(): void {
+        eventBus.emit("entityUnhovered", { entityId });
+    }
+
+    return (
+        <group position={position}>
+            <mesh
+                castShadow
+                receiveShadow
+                scale={scale}
+                onPointerDown={handleDown}
+                onPointerOver={handleOver}
+                onPointerOut={handleOut}
+            >
+                <boxGeometry />
+                <meshStandardMaterial color={colorToUse} roughness={0.8} metalness={0.0} />
+            </mesh>
+        </group>
+    );
+}
+

--- a/src/presentation/layers/FloorLayer.tsx
+++ b/src/presentation/layers/FloorLayer.tsx
@@ -1,67 +1,22 @@
 import type { JSX } from "react";
-import { useCallback } from "react";
 import { useFloors } from "@presentation/hooks/useFloors";
-import { useApplication } from "@presentation/hooks/useApplication";
-import type { RenderComponent as IRenderComponent } from "@core/types/components/RenderComponent";
+import { FloorItem } from "./FloorItem";
 
 /**
  * FloorLayer: renderiza pisos do domínio usando geometria box.
- * - Usa position como centro e size como escala.
- * - Material/Cor: tenta ler do RenderComponent da mesma entidade; fallback para `#cccccc`.
+ * Usa position como centro e size como escala.
  */
 export function FloorLayer({ color = "#cccccc" }: { readonly color?: string }): JSX.Element | null {
     const { list } = useFloors();
-    const { eventBus, entityManager } = useApplication();
 
     if (list.length === 0) return null;
 
     return (
         <>
-            {list.map(({ entityId, floor }) => {
-                // Anchor vertical na base: centerY = position.y + size.y/2
-                const position: [number, number, number] = [
-                    floor.position.x,
-                    floor.position.y + floor.size.y / 2,
-                    floor.position.z,
-                ];
-                const scale: [number, number, number] = [
-                    floor.size.x,
-                    floor.size.y,
-                    floor.size.z,
-                ];
-
-                // Tenta obter cor/material do RenderComponent
-                const rc = entityManager
-                    .getEntity(entityId)
-                    ?.getComponent<IRenderComponent>("RenderComponent");
-                const colorToUse = rc?.color ?? color;
-
-                const handleDown = useCallback(() => {
-                    eventBus.emit("entitySelected", { entityId });
-                }, [eventBus, entityId]);
-                const handleOver = useCallback(() => {
-                    eventBus.emit("entityHovered", { entityId });
-                }, [eventBus, entityId]);
-                const handleOut = useCallback(() => {
-                    eventBus.emit("entityUnhovered", { entityId });
-                }, [eventBus, entityId]);
-
-                return (
-                    <group key={entityId} position={position}>
-                        <mesh
-                            castShadow
-                            receiveShadow
-                            scale={scale}
-                            onPointerDown={handleDown}
-                            onPointerOver={handleOver}
-                            onPointerOut={handleOut}
-                        >
-                            <boxGeometry />
-                            <meshStandardMaterial color={colorToUse} roughness={0.8} metalness={0.0} />
-                        </mesh>
-                    </group>
-                );
-            })}
+            {list.map(({ entityId, floor }) => (
+                <FloorItem key={entityId} entityId={entityId} floor={floor} color={color} />
+            ))}
         </>
     );
 }
+

--- a/src/presentation/layers/ObjectItem.tsx
+++ b/src/presentation/layers/ObjectItem.tsx
@@ -1,0 +1,170 @@
+import { Suspense } from "react";
+import type { JSX } from "react";
+import { useGLTF, useTexture } from "@react-three/drei";
+import { useApplication } from "@presentation/hooks/useApplication";
+import type { EntityId } from "@core/types/ecs/EntityId";
+import type { RenderComponent as IRenderComponent } from "@core/types/components/RenderComponent";
+import type { TransformComponent as ITransformComponent } from "@core/types/components/TransformComponent";
+import type { GLTF } from "three/examples/jsm/loaders/GLTFLoader";
+import type { Texture } from "three";
+
+/**
+ * Item que representa um objeto renderizável na cena.
+ * Responsável por emitir eventos de interação e aplicar transformações.
+ */
+export function ObjectItem({
+    entityId,
+    render,
+    transform,
+}: {
+    readonly entityId: EntityId;
+    readonly render: IRenderComponent;
+    readonly transform?: ITransformComponent;
+}): JSX.Element {
+    const { eventBus } = useApplication();
+
+    const position: [number, number, number] = transform
+        ? [transform.position.x, transform.position.y, transform.position.z]
+        : [0, 0, 0];
+    const rotation: [number, number, number] = transform
+        ? [transform.rotation.x, transform.rotation.y, transform.rotation.z]
+        : [0, 0, 0];
+    const scale: [number, number, number] = transform
+        ? [transform.scale.x, transform.scale.y, transform.scale.z]
+        : [1, 1, 1];
+
+    const matProps = materialProps(render.material);
+
+    function handleDown(): void {
+        eventBus.emit("entitySelected", { entityId });
+    }
+    function handleOver(): void {
+        eventBus.emit("entityHovered", { entityId });
+    }
+    function handleOut(): void {
+        eventBus.emit("entityUnhovered", { entityId });
+    }
+
+    return (
+        <group position={position} rotation={rotation} scale={scale}>
+            <Suspense fallback={null}>
+                {render.modelUrl ? (
+                    <ModelNode
+                        url={render.modelUrl}
+                        color={render.color}
+                        textureUrl={render.textureUrl}
+                        material={matProps}
+                        visible={render.visible}
+                        onPointerDown={handleDown}
+                        onPointerOver={handleOver}
+                        onPointerOut={handleOut}
+                    />
+                ) : (
+                    <BoxNode
+                        color={render.color}
+                        material={matProps}
+                        visible={render.visible}
+                        onPointerDown={handleDown}
+                        onPointerOver={handleOver}
+                        onPointerOut={handleOut}
+                    />
+                )}
+            </Suspense>
+        </group>
+    );
+}
+
+/**
+ * Mapeia a configuração de material do domínio para props do material R3F.
+ */
+function materialProps(material: {
+    type: "basic" | "phong" | "lambert" | "standard" | "physical";
+    opacity: number;
+    transparent: boolean;
+    receiveShadow: boolean;
+    castShadow: boolean;
+    roughness?: number;
+    metalness?: number;
+}): Record<string, unknown> {
+    return {
+        opacity: material.opacity,
+        transparent: material.transparent,
+        roughness: material.roughness ?? 0.8,
+        metalness: material.metalness ?? 0.0,
+    };
+}
+
+/**
+ * Node com geometria primitiva (box) para fallback rápido.
+ */
+function BoxNode({
+    color,
+    material,
+    visible,
+    onPointerDown,
+    onPointerOver,
+    onPointerOut,
+}: {
+    readonly color: string;
+    readonly material: Record<string, unknown>;
+    readonly visible: boolean;
+    readonly onPointerDown: () => void;
+    readonly onPointerOver: () => void;
+    readonly onPointerOut: () => void;
+}): JSX.Element {
+    return (
+        <mesh
+            visible={visible}
+            castShadow
+            receiveShadow
+            onPointerDown={onPointerDown}
+            onPointerOver={onPointerOver}
+            onPointerOut={onPointerOut}
+        >
+            <boxGeometry />
+            <meshStandardMaterial color={color} {...material} />
+        </mesh>
+    );
+}
+
+/**
+ * Node que carrega um GLTF quando `url` é fornecida.
+ */
+function ModelNode({
+    url,
+    color,
+    textureUrl,
+    material,
+    visible,
+    onPointerDown,
+    onPointerOver,
+    onPointerOut,
+}: {
+    readonly url: string;
+    readonly color: string;
+    readonly textureUrl?: string;
+    readonly material: Record<string, unknown>;
+    readonly visible: boolean;
+    readonly onPointerDown: () => void;
+    readonly onPointerOver: () => void;
+    readonly onPointerOut: () => void;
+}): JSX.Element {
+    const gltf = useGLTF(url, true) as GLTF;
+    const loadedMap = useTexture(textureUrl ?? "") as Texture;
+    const map = textureUrl ? loadedMap : undefined;
+    return (
+        <primitive
+            object={gltf.scene.clone()}
+            visible={visible}
+            onPointerDown={onPointerDown}
+            onPointerOver={onPointerOver}
+            onPointerOut={onPointerOut}
+        >
+            <meshStandardMaterial attach="material" color={color} map={map} {...material} />
+        </primitive>
+    );
+}
+
+// Dica de performance: cache GLTF
+useGLTF.preload?.("/models/example.gltf");
+

--- a/src/presentation/layers/ObjectsLayer.tsx
+++ b/src/presentation/layers/ObjectsLayer.tsx
@@ -1,172 +1,25 @@
-import { Suspense, useCallback } from "react";
 import type { JSX } from "react";
-import { useGLTF, useTexture } from "@react-three/drei";
 import { useRenderObjects } from "@presentation/hooks/useRenderObjects";
-import { useApplication } from "@presentation/hooks/useApplication";
+import { ObjectItem } from "./ObjectItem";
 
 /**
  * ObjectsLayer: materializa RenderComponents do domínio em nós R3F.
  * Usa TransformComponent se disponível para posição/rotação/escala.
  */
-/**
- * ObjectsLayer: materializa RenderComponents do domínio em nós R3F.
- * - Usa TransformComponent se disponível para posição/rotação/escala.
- * - Suporta modelo via GLTF (modelUrl) ou geometria primitiva.
- * - Emite eventos de interação no EventBus: entitySelected / entityHovered / entityUnhovered.
- */
 export function ObjectsLayer(): JSX.Element {
     const { list } = useRenderObjects();
-    const { eventBus } = useApplication();
 
     return (
         <>
-            {list.map(({ entityId, render, transform }) => {
-                const position: [number, number, number] = transform
-                    ? [transform.position.x, transform.position.y, transform.position.z]
-                    : [0, 0, 0];
-                const rotation: [number, number, number] = transform
-                    ? [transform.rotation.x, transform.rotation.y, transform.rotation.z]
-                    : [0, 0, 0];
-                const scale: [number, number, number] = transform
-                    ? [transform.scale.x, transform.scale.y, transform.scale.z]
-                    : [1, 1, 1];
-
-                const matProps = materialProps(render.material);
-                const handleDown = useCallback(() => {
-                    eventBus.emit("entitySelected", { entityId });
-                }, [eventBus, entityId]);
-                const handleOver = useCallback(() => {
-                    eventBus.emit("entityHovered", { entityId });
-                }, [eventBus, entityId]);
-                const handleOut = useCallback(() => {
-                    eventBus.emit("entityUnhovered", { entityId });
-                }, [eventBus, entityId]);
-
-                return (
-                    <group key={entityId} position={position} rotation={rotation} scale={scale}>
-                        <Suspense fallback={null}>
-                            {render.modelUrl ? (
-                                <ModelNode
-                                    url={render.modelUrl}
-                                    color={render.color}
-                                    textureUrl={render.textureUrl}
-                                    material={matProps}
-                                    visible={render.visible}
-                                    onPointerDown={handleDown}
-                                    onPointerOver={handleOver}
-                                    onPointerOut={handleOut}
-                                />
-                            ) : (
-                                <BoxNode
-                                    color={render.color}
-                                    material={matProps}
-                                    visible={render.visible}
-                                    onPointerDown={handleDown}
-                                    onPointerOver={handleOver}
-                                    onPointerOut={handleOut}
-                                />
-                            )}
-                        </Suspense>
-                    </group>
-                );
-            })}
+            {list.map(({ entityId, render, transform }) => (
+                <ObjectItem
+                    key={entityId}
+                    entityId={entityId}
+                    render={render}
+                    transform={transform}
+                />
+            ))}
         </>
     );
 }
 
-/**
- * Mapeia a configuração de material do domínio para props do material R3F.
- */
-function materialProps(material: {
-    type: "basic" | "phong" | "lambert" | "standard" | "physical";
-    opacity: number;
-    transparent: boolean;
-    receiveShadow: boolean;
-    castShadow: boolean;
-    roughness?: number;
-    metalness?: number;
-}): Record<string, unknown> {
-    // Mantemos uma superfície comum usando meshStandardMaterial; ignoramos tipos específicos.
-    // Early return para simplicidade e legibilidade.
-    return {
-        opacity: material.opacity,
-        transparent: material.transparent,
-        roughness: material.roughness ?? 0.8,
-        metalness: material.metalness ?? 0.0,
-    };
-}
-
-/**
- * Node com geometria primitiva (box) para fallback rápido.
- */
-function BoxNode({
-    color,
-    material,
-    visible,
-    onPointerDown,
-    onPointerOver,
-    onPointerOut,
-}: {
-    readonly color: string;
-    readonly material: Record<string, unknown>;
-    readonly visible: boolean;
-    readonly onPointerDown: () => void;
-    readonly onPointerOver: () => void;
-    readonly onPointerOut: () => void;
-}): JSX.Element {
-    return (
-        <mesh
-            visible={visible}
-            castShadow
-            receiveShadow
-            onPointerDown={onPointerDown}
-            onPointerOver={onPointerOver}
-            onPointerOut={onPointerOut}
-        >
-            <boxGeometry />
-            <meshStandardMaterial color={color} {...material} />
-        </mesh>
-    );
-}
-
-/**
- * Node que carrega um GLTF quando `url` é fornecida.
- */
-function ModelNode({
-    url,
-    color,
-    textureUrl,
-    material,
-    visible,
-    onPointerDown,
-    onPointerOver,
-    onPointerOut,
-}: {
-    readonly url: string;
-    readonly color: string;
-    readonly textureUrl?: string;
-    readonly material: Record<string, unknown>;
-    readonly visible: boolean;
-    readonly onPointerDown: () => void;
-    readonly onPointerOver: () => void;
-    readonly onPointerOut: () => void;
-}): JSX.Element {
-    const gltf = useGLTF(url, true);
-    const map = textureUrl ? useTexture(textureUrl) : undefined;
-    return (
-        <primitive
-            object={(gltf as any).scene.clone()}
-            visible={visible}
-            onPointerDown={onPointerDown}
-            onPointerOver={onPointerOver}
-            onPointerOut={onPointerOut}
-        >
-            {/* Aplica material básico na raiz se possível */}
-            {/* Em modelos complexos, materiais específicos dos meshes prevalecem */}
-            <meshStandardMaterial attach="material" color={color} map={map as any} {...material} />
-        </primitive>
-    );
-}
-
-// Dica de performance: cache GLTF
-useGLTF.preload?.("/models/example.gltf");

--- a/src/presentation/layers/WallItem.tsx
+++ b/src/presentation/layers/WallItem.tsx
@@ -1,0 +1,67 @@
+import type { JSX } from "react";
+import { useApplication } from "@presentation/hooks/useApplication";
+import type { EntityId } from "@core/types/ecs/EntityId";
+import type { WallComponent as IWallComponent } from "@core/types/components/WallComponent";
+import type { RenderComponent as IRenderComponent } from "@core/types/components/RenderComponent";
+
+/**
+ * Item responsável por renderizar uma parede e emitir eventos de interação.
+ */
+export function WallItem({
+    entityId,
+    wall,
+    thickness,
+    color,
+}: {
+    readonly entityId: EntityId;
+    readonly wall: IWallComponent;
+    readonly thickness: number;
+    readonly color: string;
+}): JSX.Element {
+    const { eventBus, entityManager } = useApplication();
+
+    const dx = wall.end.x - wall.start.x;
+    const dz = wall.end.z - wall.start.z;
+    const length = Math.sqrt(dx * dx + dz * dz) || 0.0001;
+    const yaw = Math.atan2(dz, dx);
+    const center: [number, number, number] = [
+        (wall.start.x + wall.end.x) / 2,
+        (wall.start.y + wall.end.y) / 2 + wall.height / 2,
+        (wall.start.z + wall.end.z) / 2,
+    ];
+    const rotation: [number, number, number] = [0, yaw, 0];
+    const t = wall.thickness ?? thickness;
+    const scale: [number, number, number] = [length, wall.height, t];
+
+    const rc = entityManager
+        .getEntity(entityId)
+        ?.getComponent<IRenderComponent>("RenderComponent");
+    const colorToUse = rc?.color ?? color;
+
+    function handleDown(): void {
+        eventBus.emit("entitySelected", { entityId });
+    }
+    function handleOver(): void {
+        eventBus.emit("entityHovered", { entityId });
+    }
+    function handleOut(): void {
+        eventBus.emit("entityUnhovered", { entityId });
+    }
+
+    return (
+        <group position={center} rotation={rotation}>
+            <mesh
+                castShadow
+                receiveShadow
+                scale={scale}
+                onPointerDown={handleDown}
+                onPointerOver={handleOver}
+                onPointerOut={handleOut}
+            >
+                <boxGeometry />
+                <meshStandardMaterial color={colorToUse} roughness={0.9} metalness={0.0} />
+            </mesh>
+        </group>
+    );
+}
+

--- a/src/presentation/layers/WallsLayer.tsx
+++ b/src/presentation/layers/WallsLayer.tsx
@@ -1,72 +1,31 @@
 import type { JSX } from "react";
-import { useCallback } from "react";
 import { useWalls } from "@presentation/hooks/useWalls";
-import { useApplication } from "@presentation/hooks/useApplication";
-import type { RenderComponent as IRenderComponent } from "@core/types/components/RenderComponent";
+import { WallItem } from "./WallItem";
 
 /**
  * WallsLayer: renderiza paredes do domínio usando geometria box.
- * - Orienta cada parede pelo vetor (end - start) no plano XZ.
- * - Altura mapeada para escala Y; posição central ajustada para base no piso.
+ * Orienta cada parede pelo vetor (end - start) no plano XZ.
  */
 export function WallsLayer({ thickness = 0.12, color = "#b8b8b8" }: {
     readonly thickness?: number;
     readonly color?: string;
 }): JSX.Element | null {
     const { list } = useWalls();
-    const { eventBus, entityManager } = useApplication();
 
     if (list.length === 0) return null;
 
     return (
         <>
-            {list.map(({ entityId, wall }) => {
-                const dx = wall.end.x - wall.start.x;
-                const dz = wall.end.z - wall.start.z;
-                const length = Math.sqrt(dx * dx + dz * dz) || 0.0001;
-                const yaw = Math.atan2(dz, dx);
-                const center = [
-                    (wall.start.x + wall.end.x) / 2,
-                    (wall.start.y + wall.end.y) / 2 + wall.height / 2,
-                    (wall.start.z + wall.end.z) / 2,
-                ] as const;
-
-                const rotation: [number, number, number] = [0, yaw, 0];
-                const t = wall.thickness ?? thickness;
-                const scale: [number, number, number] = [length, wall.height, t];
-
-                // Tenta obter cor do RenderComponent da mesma entidade
-                const rc = entityManager
-                    .getEntity(entityId)
-                    ?.getComponent<IRenderComponent>("RenderComponent");
-                const colorToUse = rc?.color ?? color;
-
-                const handleDown = useCallback(() => {
-                    eventBus.emit("entitySelected", { entityId });
-                }, [eventBus, entityId]);
-                const handleOver = useCallback(() => {
-                    eventBus.emit("entityHovered", { entityId });
-                }, [eventBus, entityId]);
-                const handleOut = useCallback(() => {
-                    eventBus.emit("entityUnhovered", { entityId });
-                }, [eventBus, entityId]);
-
-                return (
-                    <group key={entityId} position={[center[0], center[1], center[2]]} rotation={rotation}>
-                        <mesh
-                            castShadow
-                            receiveShadow
-                            scale={scale}
-                            onPointerDown={handleDown}
-                            onPointerOver={handleOver}
-                            onPointerOut={handleOut}
-                        >
-                            <boxGeometry />
-                            <meshStandardMaterial color={colorToUse} roughness={0.9} metalness={0.0} />
-                        </mesh>
-                    </group>
-                );
-            })}
+            {list.map(({ entityId, wall }) => (
+                <WallItem
+                    key={entityId}
+                    entityId={entityId}
+                    wall={wall}
+                    thickness={thickness}
+                    color={color}
+                />
+            ))}
         </>
     );
 }
+

--- a/src/presentation/panels/developer/tabs/EventsTab.tsx
+++ b/src/presentation/panels/developer/tabs/EventsTab.tsx
@@ -14,7 +14,6 @@ export interface DevEventItem {
  * EventsTab: filtros, emissão e stream de eventos.
  */
 export function EventsTab({
-    events,
     filtered,
     eventFilter,
     onChangeEventFilter,
@@ -29,7 +28,6 @@ export function EventsTab({
     onToggleAutoscroll,
     onClear,
 }: {
-    readonly events: DevEventItem[];
     readonly filtered: DevEventItem[];
     readonly eventFilter: string;
     onChangeEventFilter(value: string): void;


### PR DESCRIPTION
## Summary
- extract ObjectItem, WallItem, FloorItem components
- simplify ObjectsLayer, WallsLayer, and FloorLayer to iterate with JSX
- clean up developer EventsTab props

## Testing
- `pnpm lint`
- `pnpm vitest --run`


------
https://chatgpt.com/codex/tasks/task_e_68b37dadac9c83259e8fb70c6f01dc2f