### PR TITLE
feat: implement InputManager

### DIFF
--- a/REFAC.md
+++ b/REFAC.md
@@ -105,7 +105,7 @@ A renderização é controlada por React Three Fiber (R3F) com Drei. Cada parte 
 ### **Fase 4: Input e Interação**
 
 #### **4.1 Sistema de Input**
-- [ ] Implementar InputManager
+- [x] Implementar InputManager
 - [ ] Implementar InputMapping
 - [ ] Implementar InputEvents
 - [ ] Testes para input

--- a/src/applicationInstance.ts
+++ b/src/applicationInstance.ts
@@ -7,4 +7,4 @@ import { Application } from "./Application";
  */
 const eventBus = new EventBus();
 const canvasSize: CameraDimensions = { width: window.innerWidth, height: window.innerHeight };
-export const application = new Application(eventBus, canvasSize);
+export const application = new Application(eventBus, canvasSize, window);

--- a/src/core/types/input/InputManager.ts
+++ b/src/core/types/input/InputManager.ts
@@ -1,0 +1,28 @@
+import type { EventBus } from "../../events/EventBus";
+import type { CameraSystemProvider } from "../camera/CameraSystem";
+
+/**
+ * Dependências do InputManager
+ */
+export interface InputManagerDependencies {
+    /**
+     * EventBus para publicação de eventos de input
+     */
+    readonly eventBus: EventBus;
+    /**
+     * Provedor do sistema de câmera
+     */
+    readonly cameraSystem: CameraSystemProvider;
+    /**
+     * Elemento alvo para escutar eventos
+     */
+    readonly target: HTMLElement | Window;
+}
+
+/**
+ * Provedor do InputManager
+ */
+export interface InputManagerProvider {
+    /** Remove todos os listeners registrados */
+    dispose(): void;
+}

--- a/src/core/types/input/index.ts
+++ b/src/core/types/input/index.ts
@@ -3,3 +3,4 @@
  */
 
 export type { Modifiers } from "./Modifiers";
+export type { InputManagerDependencies, InputManagerProvider } from "./InputManager";

--- a/src/infrastructure/input/InputManager.ts
+++ b/src/infrastructure/input/InputManager.ts
@@ -56,7 +56,7 @@ export class InputManager implements InputManagerProvider {
         const ndc = this.toNdc(screen);
         const world = this.toWorld(ndc);
         const modifiers = this.getModifiers(event);
-        const hudTarget = event.target !== this.target;
+        const hudTarget = this.isHudTarget(event);
         this.eventBus.emit("pointerDown", {
             worldPosition: world,
             screenPosition: screen,
@@ -73,7 +73,7 @@ export class InputManager implements InputManagerProvider {
         const ndc = this.toNdc(screen);
         const world = this.toWorld(ndc);
         const modifiers = this.getModifiers(event);
-        const hudTarget = event.target !== this.target;
+        const hudTarget = this.isHudTarget(event);
         this.eventBus.emit("pointerUp", {
             worldPosition: world,
             screenPosition: screen,
@@ -89,7 +89,7 @@ export class InputManager implements InputManagerProvider {
         const screen = Vec2Factory.create(event.clientX, event.clientY);
         const ndc = this.toNdc(screen);
         const world = this.toWorld(ndc);
-        const hudTarget = event.target !== this.target;
+        const hudTarget = this.isHudTarget(event);
         this.eventBus.emit("click", {
             worldPosition: world,
             screenPosition: screen,
@@ -154,5 +154,13 @@ export class InputManager implements InputManagerProvider {
         }
         const rect = (this.target as HTMLElement).getBoundingClientRect();
         return { width: rect.width, height: rect.height };
+    }
+
+    /** Verifica se o evento ocorreu fora do alvo */
+    private isHudTarget(event: Event): boolean {
+        if (!(this.target instanceof HTMLElement)) return false;
+        const node = event.target;
+        if (!(node instanceof Node)) return false;
+        return !this.target.contains(node);
     }
 }

--- a/src/infrastructure/input/InputManager.ts
+++ b/src/infrastructure/input/InputManager.ts
@@ -1,0 +1,158 @@
+import type { InputManagerDependencies, InputManagerProvider, Modifiers } from "@core/types/input";
+import { Vec2Factory, Vec3Factory } from "@core/geometry";
+import { Raycaster, Plane, Vector2, Vector3 } from "three";
+import type { Camera } from "three";
+
+/**
+ * Gerencia eventos de input e publica no EventBus
+ */
+export class InputManager implements InputManagerProvider {
+    private readonly eventBus: InputManagerDependencies["eventBus"];
+    private readonly cameraSystem: InputManagerDependencies["cameraSystem"];
+    private readonly target: InputManagerDependencies["target"];
+    private readonly raycaster = new Raycaster();
+    private readonly plane = new Plane(new Vector3(0, 1, 0), 0);
+    private lastScreen = Vec2Factory.create(-Infinity, -Infinity);
+
+    constructor(private readonly dependencies: InputManagerDependencies) {
+        this.eventBus = dependencies.eventBus;
+        this.cameraSystem = dependencies.cameraSystem;
+        this.target = dependencies.target;
+        this.target.addEventListener("pointermove", this.handlePointerMove);
+        this.target.addEventListener("pointerdown", this.handlePointerDown);
+        this.target.addEventListener("pointerup", this.handlePointerUp);
+        this.target.addEventListener("click", this.handleClick);
+        this.target.addEventListener("keydown", this.handleKeyDown as EventListener);
+        this.target.addEventListener("keyup", this.handleKeyUp as EventListener);
+    }
+
+    /** Remove todos os listeners registrados */
+    dispose(): void {
+        this.target.removeEventListener("pointermove", this.handlePointerMove);
+        this.target.removeEventListener("pointerdown", this.handlePointerDown);
+        this.target.removeEventListener("pointerup", this.handlePointerUp);
+        this.target.removeEventListener("click", this.handleClick);
+        this.target.removeEventListener("keydown", this.handleKeyDown as EventListener);
+        this.target.removeEventListener("keyup", this.handleKeyUp as EventListener);
+    }
+
+    /** Lida com movimento do ponteiro */
+    private handlePointerMove = (event: PointerEvent): void => {
+        const screen = Vec2Factory.create(event.clientX, event.clientY);
+        if (screen.x === this.lastScreen.x && screen.y === this.lastScreen.y) return;
+        this.lastScreen = screen;
+        const ndc = this.toNdc(screen);
+        const world = this.toWorld(ndc);
+        this.eventBus.emit("pointerMove", {
+            worldPosition: world,
+            screenPosition: screen,
+            ndc,
+        });
+    };
+
+    /** Lida com pressionar botão do ponteiro */
+    private handlePointerDown = (event: PointerEvent): void => {
+        const screen = Vec2Factory.create(event.clientX, event.clientY);
+        const ndc = this.toNdc(screen);
+        const world = this.toWorld(ndc);
+        const modifiers = this.getModifiers(event);
+        const hudTarget = event.target !== this.target;
+        this.eventBus.emit("pointerDown", {
+            worldPosition: world,
+            screenPosition: screen,
+            ndc,
+            button: event.button,
+            modifiers,
+            hudTarget,
+        });
+    };
+
+    /** Lida com soltar botão do ponteiro */
+    private handlePointerUp = (event: PointerEvent): void => {
+        const screen = Vec2Factory.create(event.clientX, event.clientY);
+        const ndc = this.toNdc(screen);
+        const world = this.toWorld(ndc);
+        const modifiers = this.getModifiers(event);
+        const hudTarget = event.target !== this.target;
+        this.eventBus.emit("pointerUp", {
+            worldPosition: world,
+            screenPosition: screen,
+            ndc,
+            button: event.button,
+            modifiers,
+            hudTarget,
+        });
+    };
+
+    /** Lida com clique do ponteiro */
+    private handleClick = (event: MouseEvent): void => {
+        const screen = Vec2Factory.create(event.clientX, event.clientY);
+        const ndc = this.toNdc(screen);
+        const world = this.toWorld(ndc);
+        const hudTarget = event.target !== this.target;
+        this.eventBus.emit("click", {
+            worldPosition: world,
+            screenPosition: screen,
+            button: event.button,
+            hudTarget,
+        });
+    };
+
+    /** Lida com pressionar tecla */
+    private handleKeyDown = (event: KeyboardEvent): void => {
+        if (event.repeat) return;
+        const modifiers = this.getModifiers(event);
+        this.eventBus.emit("keyDown", {
+            code: event.code,
+            modifiers,
+            repeat: event.repeat,
+        });
+    };
+
+    /** Lida com soltar tecla */
+    private handleKeyUp = (event: KeyboardEvent): void => {
+        const modifiers = this.getModifiers(event);
+        this.eventBus.emit("keyUp", {
+            code: event.code,
+            modifiers,
+        });
+    };
+
+    /** Converte screen position para NDC */
+    private toNdc(screen: { x: number; y: number }) {
+        const { width, height } = this.getTargetSize();
+        const x = (screen.x / width) * 2 - 1;
+        const y = -(screen.y / height) * 2 + 1;
+        return Vec2Factory.create(x, y);
+    }
+
+    /** Converte NDC para posição no mundo */
+    private toWorld(ndc: { x: number; y: number }) {
+        const camera = this.cameraSystem.getCamera() as Camera;
+        this.raycaster.setFromCamera(new Vector2(ndc.x, ndc.y), camera);
+        const intersection = new Vector3();
+        this.raycaster.ray.intersectPlane(this.plane, intersection);
+        return Vec3Factory.create(intersection.x, intersection.y, intersection.z);
+    }
+
+    /** Obtém os modificadores do evento */
+    private getModifiers(event: KeyboardEvent | PointerEvent): Modifiers {
+        return {
+            shift: event.shiftKey,
+            ctrl: event.ctrlKey,
+            alt: event.altKey,
+            meta: event.metaKey,
+            space: event instanceof KeyboardEvent && event.code === "Space",
+        };
+    }
+
+    /** Obtém tamanho do alvo */
+    private getTargetSize() {
+        if ("innerWidth" in this.target) {
+            const w = this.target as Window;
+            return { width: w.innerWidth, height: w.innerHeight };
+        }
+        const rect = (this.target as HTMLElement).getBoundingClientRect();
+        return { width: rect.width, height: rect.height };
+    }
+}

--- a/src/infrastructure/input/index.ts
+++ b/src/infrastructure/input/index.ts
@@ -1,0 +1,1 @@
+export { InputManager } from "./InputManager";

--- a/tests/unit/Application.test.ts
+++ b/tests/unit/Application.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Application } from "@/Application";
 import { EventBus } from "@core/events/EventBus";
 import { CommandStack } from "@core/commands";
 import { EntityManager } from "@domain/entities";
 import { CameraSystem } from "@infrastructure/render";
+import { InputManager } from "@infrastructure/input";
 
 describe("Application", () => {
     beforeEach(() => {
@@ -24,6 +25,7 @@ describe("Application", () => {
         expect(application.resolve("eventBus")).toBeInstanceOf(EventBus);
         expect(application.resolve("commandStack")).toBeInstanceOf(CommandStack);
         expect(application.resolve("entityManager")).toBeInstanceOf(EntityManager);
+        expect(application.resolve("inputManager")).toBeInstanceOf(InputManager);
     });
 
     it("deve lançar erro se dependência não encontrada", () => {
@@ -43,8 +45,10 @@ describe("Application", () => {
         expect(eventBus.listenerCount("entityDestroyed")).toBe(0);
         expect(eventBus.listenerCount("cameraModeChanged")).toBe(1);
 
+        const inputManager = application.resolve("inputManager");
+        const disposeSpy = vi.spyOn(inputManager, "dispose");
         application.dispose();
-
+        expect(disposeSpy).toHaveBeenCalled();
         expect(eventBus.listenerCount("componentAdded")).toBe(0);
         expect(eventBus.listenerCount("componentRemoved")).toBe(0);
         expect(eventBus.listenerCount("entityDestroyed")).toBe(0);

--- a/tests/unit/infrastructure/InputManager.test.ts
+++ b/tests/unit/infrastructure/InputManager.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
+import { InputManager } from "@infrastructure/input";
+import { EventBus } from "@core/events/EventBus";
+import type { CameraSystemProvider } from "@core/types/camera";
+import * as THREE from "three";
+
+/**
+ * Testes para InputManager
+ */
+describe("InputManager", () => {
+    let eventBus: EventBus;
+    let cameraSystem: CameraSystemProvider;
+    let inputManager: InputManager;
+    const width = 800;
+    const height = 600;
+
+    beforeAll(() => {
+        // @ts-ignore - jsdom não implementa PointerEvent
+        if (!window.PointerEvent) {
+            class PointerEventPolyfill extends MouseEvent {}
+            // @ts-ignore
+            window.PointerEvent = PointerEventPolyfill as typeof PointerEvent;
+        }
+    });
+
+    beforeEach(() => {
+        eventBus = new EventBus();
+        const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+        camera.position.set(0, 10, 10);
+        camera.lookAt(0, 0, 0);
+        cameraSystem = { getCamera: () => camera } as unknown as CameraSystemProvider;
+        Object.defineProperty(window, "innerWidth", { value: width, configurable: true });
+        Object.defineProperty(window, "innerHeight", { value: height, configurable: true });
+        inputManager = new InputManager({ eventBus, cameraSystem, target: window });
+    });
+
+    it("publica eventos de ponteiro e teclado", () => {
+        const emitSpy = vi.spyOn(eventBus, "emit");
+        window.dispatchEvent(new PointerEvent("pointermove", { clientX: 400, clientY: 300 }));
+        const moveArgs = emitSpy.mock.calls[0];
+        expect(moveArgs[0]).toBe("pointerMove");
+        expect(moveArgs[1].screenPosition).toEqual({ x: 400, y: 300 });
+        expect(moveArgs[1].ndc.x).toBeCloseTo(0);
+        expect(moveArgs[1].ndc.y).toBeCloseTo(0);
+        expect(moveArgs[1].worldPosition.y).toBeCloseTo(0);
+
+        window.dispatchEvent(
+            new PointerEvent("pointerdown", { clientX: 400, clientY: 300, button: 0 }),
+        );
+        const downArgs = emitSpy.mock.calls[1];
+        expect(downArgs[0]).toBe("pointerDown");
+        expect(downArgs[1].button).toBe(0);
+
+        window.dispatchEvent(
+            new PointerEvent("pointerup", { clientX: 400, clientY: 300, button: 0 }),
+        );
+        const upArgs = emitSpy.mock.calls[2];
+        expect(upArgs[0]).toBe("pointerUp");
+
+        window.dispatchEvent(
+            new MouseEvent("click", { clientX: 400, clientY: 300, button: 0 }),
+        );
+        const clickArgs = emitSpy.mock.calls[3];
+        expect(clickArgs[0]).toBe("click");
+
+        window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyA" }));
+        const keyDownArgs = emitSpy.mock.calls[4];
+        expect(keyDownArgs[0]).toBe("keyDown");
+        expect(keyDownArgs[1].code).toBe("KeyA");
+
+        window.dispatchEvent(new KeyboardEvent("keyup", { code: "KeyA" }));
+        const keyUpArgs = emitSpy.mock.calls[5];
+        expect(keyUpArgs[0]).toBe("keyUp");
+        expect(keyUpArgs[1].code).toBe("KeyA");
+    });
+
+    it("remove listeners ao dispose", () => {
+        const emitSpy = vi.spyOn(eventBus, "emit");
+        inputManager.dispose();
+        window.dispatchEvent(new PointerEvent("pointermove", { clientX: 10, clientY: 10 }));
+        expect(emitSpy).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/infrastructure/InputManager.test.ts
+++ b/tests/unit/infrastructure/InputManager.test.ts
@@ -50,18 +50,21 @@ describe("InputManager", () => {
         const downArgs = emitSpy.mock.calls[1];
         expect(downArgs[0]).toBe("pointerDown");
         expect(downArgs[1].button).toBe(0);
+        expect(downArgs[1].hudTarget).toBe(false);
 
         window.dispatchEvent(
             new PointerEvent("pointerup", { clientX: 400, clientY: 300, button: 0 }),
         );
         const upArgs = emitSpy.mock.calls[2];
         expect(upArgs[0]).toBe("pointerUp");
+        expect(upArgs[1].hudTarget).toBe(false);
 
         window.dispatchEvent(
             new MouseEvent("click", { clientX: 400, clientY: 300, button: 0 }),
         );
         const clickArgs = emitSpy.mock.calls[3];
         expect(clickArgs[0]).toBe("click");
+        expect(clickArgs[1].hudTarget).toBe(false);
 
         window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyA" }));
         const keyDownArgs = emitSpy.mock.calls[4];


### PR DESCRIPTION
## Summary
- add InputManager types and infrastructure implementation
- wire InputManager into Application container and instance
- cover input events with unit tests

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b4b23607088325b221a783b3d5c87c