### PR TITLE
feat: add input mapping types

### DIFF
--- a/src/core/types/input/InputAction.ts
+++ b/src/core/types/input/InputAction.ts
@@ -1,0 +1,12 @@
+/**
+ * Ações possíveis para eventos de input.
+ */
+export type InputAction =
+    | "select"
+    | "move"
+    | "place"
+    | "delete"
+    | "undo"
+    | "redo"
+    | "confirm"
+    | "cancel";

--- a/src/core/types/input/InputMapping.ts
+++ b/src/core/types/input/InputMapping.ts
@@ -1,0 +1,12 @@
+import type { Modifiers } from "./Modifiers";
+import type { InputAction } from "./InputAction";
+
+/**
+ * Define a associação entre uma tecla e uma ação.
+ */
+export interface InputMapping {
+    readonly key: string;
+    readonly action: InputAction;
+    readonly modifiers?: Modifiers;
+    readonly context?: string;
+}

--- a/src/core/types/input/index.ts
+++ b/src/core/types/input/index.ts
@@ -4,3 +4,5 @@
 
 export type { Modifiers } from "./Modifiers";
 export type { InputManagerDependencies, InputManagerProvider } from "./InputManager";
+export type { InputAction } from "./InputAction";
+export type { InputMapping } from "./InputMapping";


### PR DESCRIPTION
## Summary
- export input mapping and action types
- add type to represent allowed input actions
- define mapping interface for key-to-action associations

## Testing
- `pnpm lint`
- `pnpm vitest --run`


------
https://chatgpt.com/codex/tasks/task_e_68b4d439f470832586b5d49b79ba546a