### PR TITLE
feat: map input actions via keyboard

### DIFF
--- a/src/infrastructure/input/InputMapper.ts
+++ b/src/infrastructure/input/InputMapper.ts
@@ -1,0 +1,61 @@
+import type { InputMapping } from "@core/types/input";
+import type { InputEvents } from "@core/types/events/InputEvents";
+import { EventBus } from "@core/events/EventBus";
+
+/**
+ * Mapeia eventos de teclado para ações do sistema.
+ */
+export class InputMapper {
+    private readonly eventBus: EventBus;
+    private readonly mappings: InputMapping[] = [];
+    private context?: string;
+    private unsubscribe: () => void;
+
+    constructor(dependencies: { eventBus: EventBus; mappings?: InputMapping[] }) {
+        this.eventBus = dependencies.eventBus;
+        this.mappings.push(...(dependencies.mappings ?? []));
+        this.unsubscribe = this.eventBus.on("keyDown", this.handleKeyDown);
+    }
+
+    /** Registra um novo mapeamento */
+    registerMapping(mapping: InputMapping): void {
+        this.mappings.push(mapping);
+    }
+
+    /** Define o contexto ativo */
+    setContext(context?: string): void {
+        this.context = context;
+    }
+
+    /** Remove o listener registrado */
+    dispose(): void {
+        this.unsubscribe();
+    }
+
+    /** Lida com eventos de tecla pressionada */
+    private handleKeyDown = (event: InputEvents["keyDown"]): void => {
+        const mapping = this.mappings.find((m) => this.matches(m, event));
+        if (!mapping) return;
+        this.eventBus.emit("actionTriggered", { action: mapping.action });
+    };
+
+    /** Verifica se o evento corresponde ao mapeamento */
+    private matches(mapping: InputMapping, event: InputEvents["keyDown"]): boolean {
+        if (mapping.key !== event.code) return false;
+        if (mapping.context && mapping.context !== this.context) return false;
+        if (mapping.modifiers && !this.modifiersMatch(event.modifiers, mapping.modifiers)) return false;
+        return true;
+    }
+
+    /** Compara modificadores do evento com os do mapeamento */
+    private modifiersMatch(a: InputMapping["modifiers"], b: InputMapping["modifiers"]): boolean {
+        return (
+            a.shift === b.shift &&
+            a.ctrl === b.ctrl &&
+            a.alt === b.alt &&
+            a.meta === b.meta &&
+            a.space === b.space
+        );
+    }
+}
+

--- a/src/infrastructure/input/InputMapper.ts
+++ b/src/infrastructure/input/InputMapper.ts
@@ -8,7 +8,7 @@ import { EventBus } from "@core/events/EventBus";
 export class InputMapper {
     private readonly eventBus: EventBus;
     private readonly mappings: InputMapping[] = [];
-    private context?: string;
+    private context: string | undefined;
     private unsubscribe: () => void;
 
     constructor(dependencies: { eventBus: EventBus; mappings?: InputMapping[] }) {

--- a/src/infrastructure/input/InputMapper.ts
+++ b/src/infrastructure/input/InputMapper.ts
@@ -1,4 +1,4 @@
-import type { InputMapping } from "@core/types/input";
+import type { InputMapping, Modifiers } from "@core/types/input";
 import type { InputEvents } from "@core/types/events/InputEvents";
 import { EventBus } from "@core/events/EventBus";
 
@@ -48,7 +48,7 @@ export class InputMapper {
     }
 
     /** Compara modificadores do evento com os do mapeamento */
-    private modifiersMatch(a: InputMapping["modifiers"], b: InputMapping["modifiers"]): boolean {
+    private modifiersMatch(a: Modifiers, b: Modifiers): boolean {
         return (
             a.shift === b.shift &&
             a.ctrl === b.ctrl &&

--- a/src/infrastructure/input/index.ts
+++ b/src/infrastructure/input/index.ts
@@ -1,1 +1,2 @@
 export { InputManager } from "./InputManager";
+export { InputMapper } from "./InputMapper";

--- a/tests/unit/infrastructure/InputMapper.test.ts
+++ b/tests/unit/infrastructure/InputMapper.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { InputMapper } from "@infrastructure/input";
+import { EventBus } from "@core/events/EventBus";
+import type { InputMapping } from "@core/types/input";
+import type { Modifiers } from "@core/types/input";
+
+/**
+ * Testes para InputMapper
+ */
+describe("InputMapper", () => {
+    let eventBus: EventBus;
+    let mapper: InputMapper;
+    const baseModifiers: Modifiers = {
+        shift: false,
+        ctrl: false,
+        alt: false,
+        meta: false,
+        space: false,
+    };
+
+    beforeEach(() => {
+        eventBus = new EventBus();
+        mapper = new InputMapper({ eventBus });
+    });
+
+    it("dispara ação correspondente ao mapeamento", () => {
+        const mapping: InputMapping = { key: "KeyA", action: "select" };
+        mapper.registerMapping(mapping);
+        let triggered = "";
+        eventBus.on("actionTriggered", ({ action }) => {
+            triggered = action;
+        });
+        eventBus.emit("keyDown", { code: "KeyA", modifiers: baseModifiers, repeat: false });
+        expect(triggered).toBe("select");
+    });
+
+    it("considera modificadores ao comparar mapeamentos", () => {
+        const mapping: InputMapping = {
+            key: "KeyB",
+            action: "move",
+            modifiers: { ...baseModifiers, shift: true },
+        };
+        mapper.registerMapping(mapping);
+        let called = false;
+        eventBus.on("actionTriggered", () => {
+            called = true;
+        });
+        eventBus.emit("keyDown", { code: "KeyB", modifiers: baseModifiers, repeat: false });
+        expect(called).toBe(false);
+        eventBus.emit("keyDown", {
+            code: "KeyB",
+            modifiers: { ...baseModifiers, shift: true },
+            repeat: false,
+        });
+        expect(called).toBe(true);
+    });
+
+    it("considera contexto ao disparar ação", () => {
+        const mapping: InputMapping = {
+            key: "KeyC",
+            action: "delete",
+            context: "edit",
+        };
+        mapper.registerMapping(mapping);
+        let called = false;
+        eventBus.on("actionTriggered", () => {
+            called = true;
+        });
+        eventBus.emit("keyDown", { code: "KeyC", modifiers: baseModifiers, repeat: false });
+        expect(called).toBe(false);
+        mapper.setContext("edit");
+        eventBus.emit("keyDown", { code: "KeyC", modifiers: baseModifiers, repeat: false });
+        expect(called).toBe(true);
+    });
+
+    it("permite registrar mapeamentos após inicialização", () => {
+        const mapping: InputMapping = { key: "KeyD", action: "confirm" };
+        mapper.registerMapping(mapping);
+        let triggered = false;
+        eventBus.on("actionTriggered", () => {
+            triggered = true;
+        });
+        eventBus.emit("keyDown", { code: "KeyD", modifiers: baseModifiers, repeat: false });
+        expect(triggered).toBe(true);
+    });
+});
+

--- a/tests/unit/infrastructure/InputMapper.test.ts
+++ b/tests/unit/infrastructure/InputMapper.test.ts
@@ -83,5 +83,21 @@ describe("InputMapper", () => {
         eventBus.emit("keyDown", { code: "KeyD", modifiers: baseModifiers, repeat: false });
         expect(triggered).toBe(true);
     });
+
+    it("permite limpar o contexto ativo", () => {
+        const mapping: InputMapping = { key: "KeyE", action: "toggle", context: "mode" };
+        mapper.registerMapping(mapping);
+        let called = false;
+        eventBus.on("actionTriggered", () => {
+            called = true;
+        });
+        mapper.setContext("mode");
+        eventBus.emit("keyDown", { code: "KeyE", modifiers: baseModifiers, repeat: false });
+        expect(called).toBe(true);
+        called = false;
+        mapper.setContext();
+        eventBus.emit("keyDown", { code: "KeyE", modifiers: baseModifiers, repeat: false });
+        expect(called).toBe(false);
+    });
 });
 


### PR DESCRIPTION
## Summary
- add InputMapper to convert keyboard events into actions based on context and modifiers
- export InputMapper from infrastructure input barrel
- cover InputMapper behavior with unit tests

## Testing
- `pnpm lint`
- `pnpm vitest --run`


------
https://chatgpt.com/codex/tasks/task_e_68b4d741f76c83258020222daf8dd96a