### PR TITLE
test: add InputMapper event mapping tests

### DIFF
--- a/tests/unit/infrastructure/InputMapper.test.ts
+++ b/tests/unit/infrastructure/InputMapper.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { InputMapper } from "@infrastructure/input";
 import { EventBus } from "@core/events/EventBus";
 import type { InputMapping } from "@core/types/input";
@@ -71,6 +71,29 @@ describe("InputMapper", () => {
         mapper.setContext("edit");
         eventBus.emit("keyDown", { code: "KeyC", modifiers: baseModifiers, repeat: false });
         expect(called).toBe(true);
+    });
+
+    it("considera contexto e modificadores simultaneamente", () => {
+        const mapping: InputMapping = {
+            key: "KeyF",
+            action: "special",
+            context: "mode",
+            modifiers: { ...baseModifiers, ctrl: true },
+        };
+        mapper.registerMapping(mapping);
+        const handler = vi.fn();
+        eventBus.on("actionTriggered", handler);
+        eventBus.emit("keyDown", { code: "KeyF", modifiers: { ...baseModifiers, ctrl: true }, repeat: false });
+        expect(handler).not.toHaveBeenCalled();
+        mapper.setContext("mode");
+        eventBus.emit("keyDown", { code: "KeyF", modifiers: baseModifiers, repeat: false });
+        expect(handler).not.toHaveBeenCalled();
+        eventBus.emit("keyDown", {
+            code: "KeyF",
+            modifiers: { ...baseModifiers, ctrl: true },
+            repeat: false,
+        });
+        expect(handler).toHaveBeenCalledTimes(1);
     });
 
     it("permite registrar mapeamentos após inicialização", () => {


### PR DESCRIPTION
## Summary
- add InputMapper unit tests that simulate `keyDown` events through the EventBus
- verify `actionTriggered` emissions for mappings with modifiers and contexts

## Testing
- `pnpm lint`
- `pnpm test tests/unit/infrastructure/InputMapper.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68b50d2380d08325b576e47cb7aa3994