### PR TITLE
feat: add object selection system

### DIFF
--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -11,3 +11,4 @@ export * from "./ui";
 export * from "./scene";
 export * from "./render";
 export * from "./snap";
+export * from "./picking";

--- a/src/core/types/picking/ObjectSelection.ts
+++ b/src/core/types/picking/ObjectSelection.ts
@@ -1,0 +1,26 @@
+import type { EventBus } from "../../events/EventBus";
+import type { CameraSystemProvider } from "../camera/CameraSystem";
+import type { CollisionBody } from "@core/geometry";
+import type { EntityId } from "../ecs/EntityId";
+
+/**
+ * Dependências para o sistema de seleção de objetos
+ */
+export interface ObjectSelectionDependencies {
+    /** EventBus para ouvir eventos de input e publicar seleção */
+    readonly eventBus: EventBus;
+    /** Sistema de câmera para criar raios a partir da tela */
+    readonly cameraSystem: CameraSystemProvider;
+    /** Função que retorna os corpos disponíveis para raycasting */
+    readonly getCollisionBodies: () => CollisionBody[];
+}
+
+/**
+ * Provedor do sistema de seleção de objetos
+ */
+export interface ObjectSelectionProvider {
+    /** Retorna IDs das entidades selecionadas */
+    getSelected(): EntityId[];
+    /** Remove todos os listeners registrados */
+    dispose(): void;
+}

--- a/src/core/types/picking/index.ts
+++ b/src/core/types/picking/index.ts
@@ -1,0 +1,4 @@
+export type {
+    ObjectSelectionDependencies,
+    ObjectSelectionProvider,
+} from "./ObjectSelection";

--- a/src/infrastructure/picking/ObjectSelection.ts
+++ b/src/infrastructure/picking/ObjectSelection.ts
@@ -1,0 +1,88 @@
+import { Raycaster, Vector2 } from "three";
+import type { Camera } from "three";
+import { CollisionFactory, CollisionDetection, Vec3Factory } from "@core/geometry";
+import type { EntityId } from "@core/types/ecs/EntityId";
+import type { ObjectSelectionDependencies, ObjectSelectionProvider } from "@core/types/picking";
+import type { InputEvents } from "@core/types/events/InputEvents";
+import type { Unsubscribe } from "@core/types/Events";
+
+/**
+ * Sistema de seleção de objetos baseado em raycasting
+ */
+export class ObjectSelection implements ObjectSelectionProvider {
+    private readonly eventBus: ObjectSelectionDependencies["eventBus"];
+    private readonly cameraSystem: ObjectSelectionDependencies["cameraSystem"];
+    private readonly getCollisionBodies: ObjectSelectionDependencies["getCollisionBodies"];
+    private readonly raycaster = new Raycaster();
+    private readonly selected = new Set<EntityId>();
+    private readonly unsubscribe: Unsubscribe;
+
+    constructor(private readonly dependencies: ObjectSelectionDependencies) {
+        this.eventBus = dependencies.eventBus;
+        this.cameraSystem = dependencies.cameraSystem;
+        this.getCollisionBodies = dependencies.getCollisionBodies;
+        this.unsubscribe = this.eventBus.on("pointerDown", this.handlePointerDown);
+    }
+
+    /** Retorna os IDs atualmente selecionados */
+    getSelected(): EntityId[] {
+        return Array.from(this.selected);
+    }
+
+    /** Remove listener registrado */
+    dispose(): void {
+        this.unsubscribe();
+    }
+
+    /** Processa eventos de ponteiro para realizar seleção */
+    private handlePointerDown = ({ ndc, button, hudTarget }: InputEvents["pointerDown"]): void => {
+        if (button !== 0 || hudTarget) return;
+
+        const camera = this.cameraSystem.getCamera() as Camera;
+        this.raycaster.setFromCamera(new Vector2(ndc.x, ndc.y), camera);
+
+        const origin = Vec3Factory.create(
+            this.raycaster.ray.origin.x,
+            this.raycaster.ray.origin.y,
+            this.raycaster.ray.origin.z,
+        );
+        const direction = Vec3Factory.create(
+            this.raycaster.ray.direction.x,
+            this.raycaster.ray.direction.y,
+            this.raycaster.ray.direction.z,
+        );
+        const query = CollisionFactory.createRaycastQuery({ origin, direction });
+        const result = CollisionDetection.raycastBodies(query, this.getCollisionBodies());
+
+        if (result.hit && result.body) {
+            this.select(result.body.id as EntityId);
+            return;
+        }
+
+        this.clear();
+    };
+
+    /** Seleciona uma entidade e emite eventos */
+    private select(id: EntityId): void {
+        if (this.selected.has(id) && this.selected.size === 1) return;
+
+        if (this.selected.size > 0) {
+            const prev = Array.from(this.selected);
+            this.selected.clear();
+            prev.forEach((pid) => this.eventBus.emit("entityDeselected", { entityId: pid }));
+        }
+
+        this.selected.add(id);
+        this.eventBus.emit("entitySelected", { entityId: id });
+        this.eventBus.emit("selectionChanged", { selectedIds: Array.from(this.selected) });
+    }
+
+    /** Limpa seleção atual e emite eventos */
+    private clear(): void {
+        if (this.selected.size === 0) return;
+        const prev = Array.from(this.selected);
+        this.selected.clear();
+        prev.forEach((pid) => this.eventBus.emit("entityDeselected", { entityId: pid }));
+        this.eventBus.emit("selectionChanged", { selectedIds: [] });
+    }
+}

--- a/src/infrastructure/picking/index.ts
+++ b/src/infrastructure/picking/index.ts
@@ -1,0 +1,1 @@
+export { ObjectSelection } from "./ObjectSelection";

--- a/tests/unit/infrastructure/ObjectSelection.test.ts
+++ b/tests/unit/infrastructure/ObjectSelection.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EventBus } from "@core/events/EventBus";
+import { ObjectSelection } from "@infrastructure/picking";
+import { CollisionFactory, Vec3Factory } from "@core/geometry";
+import type { CameraSystemProvider } from "@core/types/camera";
+import * as THREE from "three";
+
+/**
+ * Testes para ObjectSelection
+ */
+describe("ObjectSelection", () => {
+    let eventBus: EventBus;
+    let cameraSystem: CameraSystemProvider;
+    let bodies: ReturnType<typeof CollisionFactory.createCollisionBodyFromBox>[];
+    let selection: ObjectSelection;
+
+    beforeEach(() => {
+        eventBus = new EventBus();
+        const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+        camera.position.set(0, 0, 5);
+        camera.lookAt(0, 0, 0);
+        cameraSystem = { getCamera: () => camera } as CameraSystemProvider;
+        const body = CollisionFactory.createCollisionBodyFromBox({
+            id: "obj1",
+            position: Vec3Factory.create(0, 0, 0),
+            size: Vec3Factory.create(1, 1, 1),
+        });
+        bodies = [body];
+        selection = new ObjectSelection({
+            eventBus,
+            cameraSystem,
+            getCollisionBodies: () => bodies,
+        });
+    });
+
+    it("seleciona e desseleciona objetos", () => {
+        const emitSpy = vi.spyOn(eventBus, "emit");
+        eventBus.emit("pointerDown", {
+            worldPosition: Vec3Factory.create(0, 0, 0),
+            screenPosition: { x: 0, y: 0 },
+            ndc: { x: 0, y: 0 },
+            button: 0,
+            modifiers: { shift: false, ctrl: false, alt: false, meta: false, space: false },
+            hudTarget: false,
+        });
+
+        const selectedCall = emitSpy.mock.calls.find(([t]) => t === "entitySelected");
+        expect(selectedCall?.[1]).toEqual({ entityId: "obj1" });
+        const changeCalls = emitSpy.mock.calls.filter(([t]) => t === "selectionChanged");
+        expect(changeCalls[0][1]).toEqual({ selectedIds: ["obj1"] });
+
+        bodies.length = 0;
+        eventBus.emit("pointerDown", {
+            worldPosition: Vec3Factory.create(0, 0, 0),
+            screenPosition: { x: 0, y: 0 },
+            ndc: { x: 0, y: 0 },
+            button: 0,
+            modifiers: { shift: false, ctrl: false, alt: false, meta: false, space: false },
+            hudTarget: false,
+        });
+        const deselectedCall = emitSpy.mock.calls.find(([t]) => t === "entityDeselected");
+        expect(deselectedCall?.[1]).toEqual({ entityId: "obj1" });
+        const finalChangeCalls = emitSpy.mock.calls.filter(([t]) => t === "selectionChanged");
+        expect(finalChangeCalls[1][1]).toEqual({ selectedIds: [] });
+    });
+
+    it("remove listener ao dispose", () => {
+        selection.dispose();
+        const emitSpy = vi.spyOn(eventBus, "emit");
+        eventBus.emit("pointerDown", {
+            worldPosition: Vec3Factory.create(0, 0, 0),
+            screenPosition: { x: 0, y: 0 },
+            ndc: { x: 0, y: 0 },
+            button: 0,
+            modifiers: { shift: false, ctrl: false, alt: false, meta: false, space: false },
+            hudTarget: false,
+        });
+        const selectedCall = emitSpy.mock.calls.find(([t]) => t === "entitySelected");
+        expect(selectedCall).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- add object selection types and implementation
- enable selecting entities via raycasting
- cover selection with unit tests

## Testing
- `pnpm lint`
- `pnpm vitest --run`
- `npx -y madge --circular src --extensions ts,tsx --ts-config tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68b7a0664d808325b1704b04f9084451