### PR TITLE
docs: add legacy feature comparison

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,7 @@ Se detectar divergência entre arquivos:
 5) Por fim, demais fontes.
 Se ainda houver ambiguidade: proponha 2–3 opções e escolha a mais aderente a `/.cursor/.cursorrules` e ao `CONTEXT.md`.
 ```
+
+### Documentos de Apoio
+
+- Consulte `docs/comparison.md` para o mapeamento de funcionalidades portadas do legado.

--- a/README.md
+++ b/README.md
@@ -163,3 +163,4 @@ Arquivos úteis:
 ## **Projecto Legacy (Legado)**
 
 O código antigo está preservado em `legacy/` para referência durante a migração.
+Veja `docs/comparison.md` para o mapeamento de funcionalidades portadas do legado.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,46 @@
+# Comparação de Funcionalidades
+
+Este documento resume as funcionalidades do legado e indica o status de port para a nova base descrita no README principal.
+
+Funcionalidades marcadas com `[x]` já possuem correspondência no novo README. As marcadas com `[ ]` ainda não foram portadas ou documentadas.
+
+## Ferramentas
+- [ ] place
+- [ ] move
+- [ ] wall
+- [ ] floor
+- [ ] bulldoze
+- [ ] eyedropper
+
+## HUD e Interface
+- [ ] Topbar
+- [ ] BudgetBar
+- [ ] Toolbar
+- [ ] Catálogo
+- [ ] Inspector flutuante
+
+## Arquivos
+- [ ] Exportar lote em JSON
+- [ ] Importar lote em JSON
+- [ ] Exportar thumbnail do Canvas
+
+## Validação e Orçamento
+- [ ] Pipeline de validação (bounds/colisão)
+- [ ] Verificação de orçamento via decorator
+- [ ] Toasts globais de feedback
+
+## Controles e Interação
+- [x] Modos de câmera perspectiva/ortográfica
+- [x] Pan, rotação e zoom
+- [ ] Interações específicas de ferramentas (R para rotacionar, ESC para cancelar)
+
+## Undo/Redo
+- [x] Histórico de ações com Command Pattern
+
+## Renderização
+- [x] Camadas de cena (Grid, Walls, Floor, Objects, Gizmo, Camera, Controls)
+- [ ] Instancing para otimização
+
+## Catálogo e Serialização
+- [ ] Catálogo validado com Zod
+- [ ] Exportação/importação versionada de lotes


### PR DESCRIPTION
## Summary
- add comparison of legacy features with new architecture
- reference comparison doc from README and AGENTS instructions

## Testing
- `pnpm lint`
- `pnpm vitest --run`


------
https://chatgpt.com/codex/tasks/task_e_68b7af39987483259f5fee4c5504a1bc