### PR TITLE
feat: add basic tool strategies

### DIFF
--- a/src/application/tools/basic/DeleteTool.ts
+++ b/src/application/tools/basic/DeleteTool.ts
@@ -1,0 +1,25 @@
+import type { EventBus } from "@core/events/EventBus";
+import type { EntityId } from "@core/types/ecs/EntityId";
+import type { ToolStrategy } from "../strategies/ToolStrategy";
+
+/**
+ * Ferramenta de deleção de entidades
+ */
+export class DeleteTool implements ToolStrategy {
+    constructor(private readonly eventBus: EventBus) {}
+
+    /** Ativa a ferramenta */
+    activate(): void {}
+
+    /** Desativa a ferramenta */
+    deactivate(): void {}
+
+    /** Lida com input de deleção */
+    handleInput(input: { entityId: EntityId; type?: string }): void {
+        if (!input?.entityId) return;
+        this.eventBus.emit("entityDestroyed", {
+            entityId: input.entityId,
+            type: input.type ?? "unknown",
+        });
+    }
+}

--- a/src/application/tools/basic/MoveTool.ts
+++ b/src/application/tools/basic/MoveTool.ts
@@ -1,0 +1,22 @@
+import type { EventBus } from "@core/events/EventBus";
+import type { EntityId } from "@core/types/ecs/EntityId";
+import type { ToolStrategy } from "../strategies/ToolStrategy";
+
+/**
+ * Ferramenta de movimentação de entidades
+ */
+export class MoveTool implements ToolStrategy {
+    constructor(private readonly eventBus: EventBus) {}
+
+    /** Ativa a ferramenta */
+    activate(): void {}
+
+    /** Desativa a ferramenta */
+    deactivate(): void {}
+
+    /** Lida com input de movimentação */
+    handleInput(input: { entityId: EntityId }): void {
+        if (!input?.entityId) return;
+        this.eventBus.emit("entityMoved", { entityId: input.entityId });
+    }
+}

--- a/src/application/tools/basic/PlaceTool.ts
+++ b/src/application/tools/basic/PlaceTool.ts
@@ -1,0 +1,22 @@
+import type { EventBus } from "@core/events/EventBus";
+import type { EntityId } from "@core/types/ecs/EntityId";
+import type { ToolStrategy } from "../strategies/ToolStrategy";
+
+/**
+ * Ferramenta de colocação de objetos
+ */
+export class PlaceTool implements ToolStrategy {
+    constructor(private readonly eventBus: EventBus) {}
+
+    /** Ativa a ferramenta */
+    activate(): void {}
+
+    /** Desativa a ferramenta */
+    deactivate(): void {}
+
+    /** Lida com input de posicionamento */
+    handleInput(input: { entityId: EntityId }): void {
+        if (!input?.entityId) return;
+        this.eventBus.emit("objectPlaced", { entityId: input.entityId });
+    }
+}

--- a/src/application/tools/basic/SelectTool.ts
+++ b/src/application/tools/basic/SelectTool.ts
@@ -1,0 +1,22 @@
+import type { EventBus } from "@core/events/EventBus";
+import type { EntityId } from "@core/types/ecs/EntityId";
+import type { ToolStrategy } from "../strategies/ToolStrategy";
+
+/**
+ * Ferramenta de seleção de entidades
+ */
+export class SelectTool implements ToolStrategy {
+    constructor(private readonly eventBus: EventBus) {}
+
+    /** Ativa a ferramenta */
+    activate(): void {}
+
+    /** Desativa a ferramenta */
+    deactivate(): void {}
+
+    /** Lida com input de seleção */
+    handleInput(input: { entityId: EntityId }): void {
+        if (!input?.entityId) return;
+        this.eventBus.emit("entitySelected", { entityId: input.entityId });
+    }
+}

--- a/src/application/tools/basic/ViewTool.ts
+++ b/src/application/tools/basic/ViewTool.ts
@@ -1,0 +1,20 @@
+import type { EventBus } from "@core/events/EventBus";
+import type { ToolStrategy } from "../strategies/ToolStrategy";
+
+/**
+ * Ferramenta de visualização
+ */
+export class ViewTool implements ToolStrategy {
+    constructor(private readonly eventBus: EventBus) {}
+
+    /** Ativa a ferramenta */
+    activate(): void {
+        this.eventBus.emit("modeChanged", { mode: "view" });
+    }
+
+    /** Desativa a ferramenta */
+    deactivate(): void {}
+
+    /** Lida com input (não utilizado) */
+    handleInput(): void {}
+}

--- a/src/application/tools/basic/index.ts
+++ b/src/application/tools/basic/index.ts
@@ -1,0 +1,20 @@
+import type { EventBus } from "@core/events/EventBus";
+import type { ToolManager } from "../ToolManager";
+import { ViewTool } from "./ViewTool";
+import { SelectTool } from "./SelectTool";
+import { PlaceTool } from "./PlaceTool";
+import { MoveTool } from "./MoveTool";
+import { DeleteTool } from "./DeleteTool";
+
+/**
+ * Registra ferramentas básicas no ToolManager
+ */
+export function registerBasicTools(toolManager: ToolManager, eventBus: EventBus): void {
+    toolManager.register("view", new ViewTool(eventBus));
+    toolManager.register("select", new SelectTool(eventBus));
+    toolManager.register("place", new PlaceTool(eventBus));
+    toolManager.register("move", new MoveTool(eventBus));
+    toolManager.register("delete", new DeleteTool(eventBus));
+}
+
+export { ViewTool, SelectTool, PlaceTool, MoveTool, DeleteTool };

--- a/src/core/types/events/EntityEvents.ts
+++ b/src/core/types/events/EntityEvents.ts
@@ -11,4 +11,6 @@ export interface EntityEvents {
     componentRemoved: { entityId: EntityId; componentType: string };
     componentUpdated: { entityId: EntityId; component: Component };
     entityUpdated: { entityId: EntityId };
+    entityMoved: { entityId: EntityId };
+    objectPlaced: { entityId: EntityId };
 }

--- a/tests/unit/application/tools/basic/DeleteTool.test.ts
+++ b/tests/unit/application/tools/basic/DeleteTool.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolManager } from "@application/tools/ToolManager";
+import { EventBus } from "@core/events/EventBus";
+import { registerBasicTools } from "@application/tools/basic";
+
+/**
+ * Testes para DeleteTool
+ */
+describe("DeleteTool", () => {
+    it("emite entityDestroyed ao deletar", () => {
+        const eventBus = new EventBus();
+        const emit = vi.spyOn(eventBus, "emit");
+        const manager = new ToolManager(eventBus);
+        registerBasicTools(manager, eventBus);
+
+        manager.activate("delete");
+        const entityId = "e1";
+        manager.handleInput({ entityId, type: "object" });
+
+        expect(emit).toHaveBeenCalledWith("entityDestroyed", {
+            entityId,
+            type: "object",
+        });
+    });
+});

--- a/tests/unit/application/tools/basic/MoveTool.test.ts
+++ b/tests/unit/application/tools/basic/MoveTool.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolManager } from "@application/tools/ToolManager";
+import { EventBus } from "@core/events/EventBus";
+import { registerBasicTools } from "@application/tools/basic";
+
+/**
+ * Testes para MoveTool
+ */
+describe("MoveTool", () => {
+    it("emite entityMoved ao mover", () => {
+        const eventBus = new EventBus();
+        const emit = vi.spyOn(eventBus, "emit");
+        const manager = new ToolManager(eventBus);
+        registerBasicTools(manager, eventBus);
+
+        manager.activate("move");
+        const entityId = "e1";
+        manager.handleInput({ entityId });
+
+        expect(emit).toHaveBeenCalledWith("entityMoved", { entityId });
+    });
+});

--- a/tests/unit/application/tools/basic/PlaceTool.test.ts
+++ b/tests/unit/application/tools/basic/PlaceTool.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolManager } from "@application/tools/ToolManager";
+import { EventBus } from "@core/events/EventBus";
+import { registerBasicTools } from "@application/tools/basic";
+
+/**
+ * Testes para PlaceTool
+ */
+describe("PlaceTool", () => {
+    it("emite objectPlaced ao posicionar", () => {
+        const eventBus = new EventBus();
+        const emit = vi.spyOn(eventBus, "emit");
+        const manager = new ToolManager(eventBus);
+        registerBasicTools(manager, eventBus);
+
+        manager.activate("place");
+        const entityId = "e1";
+        manager.handleInput({ entityId });
+
+        expect(emit).toHaveBeenCalledWith("objectPlaced", { entityId });
+    });
+});

--- a/tests/unit/application/tools/basic/SelectTool.test.ts
+++ b/tests/unit/application/tools/basic/SelectTool.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolManager } from "@application/tools/ToolManager";
+import { EventBus } from "@core/events/EventBus";
+import { registerBasicTools } from "@application/tools/basic";
+
+/**
+ * Testes para SelectTool
+ */
+describe("SelectTool", () => {
+    it("emite entitySelected ao selecionar", () => {
+        const eventBus = new EventBus();
+        const emit = vi.spyOn(eventBus, "emit");
+        const manager = new ToolManager(eventBus);
+        registerBasicTools(manager, eventBus);
+
+        manager.activate("select");
+        const entityId = "e1";
+        manager.handleInput({ entityId });
+
+        expect(emit).toHaveBeenCalledWith("entitySelected", { entityId });
+    });
+});

--- a/tests/unit/application/tools/basic/ViewTool.test.ts
+++ b/tests/unit/application/tools/basic/ViewTool.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolManager } from "@application/tools/ToolManager";
+import { EventBus } from "@core/events/EventBus";
+import { registerBasicTools } from "@application/tools/basic";
+
+/**
+ * Testes para ViewTool
+ */
+describe("ViewTool", () => {
+    it("emite modeChanged ao ativar", () => {
+        const eventBus = new EventBus();
+        const emit = vi.spyOn(eventBus, "emit");
+        const manager = new ToolManager(eventBus);
+        registerBasicTools(manager, eventBus);
+
+        manager.activate("view");
+
+        expect(emit).toHaveBeenCalledWith("modeChanged", { mode: "view" });
+    });
+});


### PR DESCRIPTION
## Summary
- add basic tool strategies for view, select, place, move and delete operations
- register tools in ToolManager and expose helper
- emit object and entity events for each tool
- test basic tool strategies

## Testing
- `pnpm lint`
- `pnpm vitest --run`

------
https://chatgpt.com/codex/tasks/task_e_68b90070fe408325ba583b591eb4789d