### PR TITLE
Integrate ToolManager with HUD selection

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -8,6 +8,8 @@ import { CommandStack } from "@core/commands";
 import { EntityManager } from "@domain/entities";
 import { CameraSystem, CameraController, RenderLoop } from "@infrastructure/render";
 import { InputManager, InputMapper } from "@infrastructure/input";
+import { ToolManager } from "@application/tools/ToolManager";
+import { registerBasicTools } from "@application/tools/basic";
 
 /**
  * Classe principal da aplicação
@@ -66,6 +68,8 @@ export class Application {
         const renderLoop = new RenderLoop();
         const inputManager = new InputManager({ eventBus, cameraSystem, target: inputTarget });
         const inputMapper = new InputMapper({ eventBus });
+        const toolManager = new ToolManager(eventBus);
+        registerBasicTools(toolManager, eventBus);
 
         this.container.set("eventBus", eventBus);
         this.container.set("commandStack", commandStack);
@@ -75,6 +79,7 @@ export class Application {
         this.container.set("renderLoop", renderLoop);
         this.container.set("inputManager", inputManager);
         this.container.set("inputMapper", inputMapper);
+        this.container.set("toolManager", toolManager);
 
         return {
             eventBus,
@@ -85,6 +90,7 @@ export class Application {
             renderLoop,
             inputManager,
             inputMapper,
+            toolManager,
         } as DependencyMap;
     }
 
@@ -113,6 +119,7 @@ type DependencyMap = {
     renderLoop: RenderLoop;
     inputManager: InputManager;
     inputMapper: InputMapper;
+    toolManager: ToolManager;
 };
 
 /**

--- a/src/application/tools/ToolManager.ts
+++ b/src/application/tools/ToolManager.ts
@@ -30,6 +30,15 @@ export class ToolManager {
         this.eventBus.emit("toolActivated", { tool });
     }
 
+    /** Define a ferramenta ativa ou desativa quando null */
+    setActive(tool: ToolType | null): void {
+        if (!tool) {
+            this.deactivate();
+            return;
+        }
+        this.activate(tool);
+    }
+
     /** Desativa a ferramenta ativa */
     deactivate(): void {
         if (!this.activeTool) return;

--- a/src/presentation/hooks/useApplication.ts
+++ b/src/presentation/hooks/useApplication.ts
@@ -5,6 +5,7 @@ import type { EventBus } from "@core/events/EventBus";
 import type { CameraSystem } from "@infrastructure/render/CameraSystem";
 import type { CameraController } from "@infrastructure/render/CameraController";
 import type { RenderLoop } from "@infrastructure/render/RenderLoop";
+import type { ToolManager } from "@application/tools/ToolManager";
 
 /**
  * Hook que expõe dependências principais da aplicação
@@ -16,6 +17,7 @@ export function useApplication(): {
     cameraSystem: CameraSystem;
     cameraController: CameraController;
     renderLoop: RenderLoop;
+    toolManager: ToolManager;
 } {
     return {
         eventBus: application.resolve("eventBus"),
@@ -24,5 +26,6 @@ export function useApplication(): {
         cameraSystem: application.resolve("cameraSystem"),
         cameraController: application.resolve("cameraController"),
         renderLoop: application.resolve("renderLoop"),
+        toolManager: application.resolve("toolManager"),
     };
 }

--- a/src/presentation/hooks/useHudState.ts
+++ b/src/presentation/hooks/useHudState.ts
@@ -14,6 +14,7 @@ export function useHudState(): {
     toggleMode: (next: Exclude<HudMode, null>) => void;
     selectOption: (m: Exclude<HudMode, null>, key: string) => void;
     selectCatalogItem: (key: string) => void;
+    setMode: (m: HudMode) => void;
 } {
     const [mode, setMode] = useState<HudMode>(null);
     const [selected, setSelected] = useState<HudSelection>({});
@@ -79,5 +80,6 @@ export function useHudState(): {
         toggleMode,
         selectOption,
         selectCatalogItem,
+        setMode,
     };
 }

--- a/tests/unit/presentation/ToolHud.integration.test.tsx
+++ b/tests/unit/presentation/ToolHud.integration.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { EventBus } from "@core/events/EventBus";
+
+let eventBus: EventBus;
+const toolManager = { setActive: vi.fn() };
+
+vi.mock("@presentation/hooks/useApplication", () => ({
+    useApplication: () => ({ eventBus, toolManager }),
+}));
+
+import { ToolHud } from "@presentation/hud/ToolHud";
+
+describe("ToolHud integration", () => {
+    beforeEach(() => {
+        eventBus = new EventBus();
+        toolManager.setActive.mockClear();
+    });
+
+    it("chama ToolManager.setActive ao selecionar ferramenta", () => {
+        render(<ToolHud />);
+        fireEvent.click(screen.getByLabelText("Buy (modo)"));
+        fireEvent.click(screen.getByLabelText("mover"));
+        expect(toolManager.setActive).toHaveBeenCalledWith("move");
+    });
+
+    it("atualiza modo ao receber evento modeChanged", () => {
+        render(<ToolHud />);
+        act(() => {
+            eventBus.emit("modeChanged", { mode: "build" });
+        });
+        expect(screen.getByLabelText("Build (modo)")).toHaveAttribute("aria-pressed", "true");
+    });
+});

--- a/tests/unit/presentation/hud/ToolHud.test.tsx
+++ b/tests/unit/presentation/hud/ToolHud.test.tsx
@@ -5,6 +5,7 @@ import { EventBus } from "@core/events/EventBus";
 import type { Modifiers } from "@core/types/input";
 
 let eventBus: EventBus;
+const toolManager = { setActive: vi.fn() };
 const baseModifiers: Modifiers = {
     shift: false,
     ctrl: false,
@@ -14,7 +15,7 @@ const baseModifiers: Modifiers = {
 };
 
 vi.mock("@presentation/hooks/useApplication", () => ({
-    useApplication: () => ({ eventBus }),
+    useApplication: () => ({ eventBus, toolManager }),
 }));
 
 describe("ToolHud atalhos de teclado", () => {


### PR DESCRIPTION
## Summary
- expose ToolManager via application container and hook
- drive HUD selection through ToolManager.setActive and modeChanged events
- cover ToolHud integration with tests

## Testing
- `pnpm test tests/unit/presentation/ToolHud.integration.test.tsx`
- `pnpm test tests/unit/presentation/hud/ToolHud.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b90ed3f98c832599132b1cee296242