### PR TITLE
Integrate ToolManager with HUD selection

### DIFF
--- a/src/systems/tools/ToolManager.tsx
+++ b/src/systems/tools/ToolManager.tsx
@@ -7,8 +7,9 @@ import { StrategyComponent, ToolContext } from "./strategies/types";
 export function ToolManager({ strategies }: { strategies: Record<Tool, StrategyComponent> }) {
   const { camera, gl, scene } = useThree();
   const activeTool = useStore((s) => s.activeTool);
+  const mode = useStore((s) => s.mode);
   const ctx = useMemo<ToolContext>(() => ({ camera, gl, scene }), [camera, gl, scene]);
-  const Strategy = strategies[activeTool];
+  const Strategy = mode === "view" ? null : strategies[activeTool];
   return Strategy ? <Strategy ctx={ctx} /> : null;
 }
 


### PR DESCRIPTION
## Summary
- avoid rendering active tools when HUD is in view mode

## Testing
- `pnpm lint` *(fails: Unknown property 'depthTest' and other existing errors)*
- `pnpm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b911d00c288325b47cdc5e9ef0c727